### PR TITLE
Make namespace a class attribute for each individual class, rather than a module-level constant.

### DIFF
--- a/fairgraph/base.py
+++ b/fairgraph/base.py
@@ -70,6 +70,10 @@ class Registry(type):
         register_class(cls)
         return cls
 
+    @property
+    def path(cls):
+        return cls.namespace + cls._path
+
 
 #class KGObject(object, metaclass=Registry):
 class KGObject(with_metaclass(Registry, object)):
@@ -159,7 +163,7 @@ class KGObject(with_metaclass(Registry, object)):
                 self.id = self.save_cache[self.__class__][query_cache_key]
                 return True
             else:
-                response = client.filter_query(self.path, query_filter, context)
+                response = client.filter_query(self.__class__.path, query_filter, context)
                 if response:
                     self.id = response[0].data["@id"]
                     KGObject.save_cache[self.__class__][query_cache_key] = self.id

--- a/fairgraph/base.py
+++ b/fairgraph/base.py
@@ -72,6 +72,8 @@ class Registry(type):
 
     @property
     def path(cls):
+        if cls.namespace is None:
+            raise ValueError("namespace not set")
         return cls.namespace + cls._path
 
 

--- a/fairgraph/brainsimulation.py
+++ b/fairgraph/brainsimulation.py
@@ -43,7 +43,8 @@ class HasAliasMixin(object):
 
 class ModelProject(KGObject, HasAliasMixin):
     """docstring"""
-    path = NAMESPACE + "/simulation/modelproject/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/simulation/modelproject/v0.1.0"
     #path = NAMESPACE + "/simulation/modelproject/v0.1.1"
     type = ["prov:Entity", "nsg:ModelProject"]
 
@@ -314,7 +315,8 @@ class ModelProject(KGObject, HasAliasMixin):
 class ModelInstance(KGObject):
     """docstring"""
     #path = NAMESPACE + "/simulation/modelinstance/v0.1.2"
-    path = NAMESPACE + "/simulation/modelinstance/v0.1.1"
+    namespace = NAMESPACE
+    _path = "/simulation/modelinstance/v0.1.1"
     type = ["prov:Entity", "nsg:ModelInstance"]
     # ScientificModelInstance
     #   - model -> linked ModelProject using partOf
@@ -431,7 +433,8 @@ class ModelInstance(KGObject):
 
 class MEModel(ModelInstance):
     """docstring"""
-    path = NAMESPACE + "/simulation/memodel/v0.1.2"  # latest is 0.1.4, but all the data is currently under 0.1.2
+    namespace = NAMESPACE
+    _path = "/simulation/memodel/v0.1.2"  # latest is 0.1.4, but all the data is currently under 0.1.2
     type = ["prov:Entity", "nsg:MEModel", "nsg:ModelInstance"]
     context = [
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",
@@ -537,7 +540,8 @@ class MEModel(ModelInstance):
 
 
 class Morphology(KGObject):
-    path = NAMESPACE + "/simulation/morphology/v0.1.1"
+    namespace = NAMESPACE
+    _path = "/simulation/morphology/v0.1.1"
     type = ["prov:Entity", "nsg:Morphology"]
     context = [
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",
@@ -599,7 +603,8 @@ class Morphology(KGObject):
 
 
 class ModelScript(KGObject):
-    path = NAMESPACE + "/simulation/emodelscript/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/simulation/emodelscript/v0.1.0"
     type = ["prov:Entity", "nsg:EModelScript"]  # generalize to other sub-types of script
     context =  [  # todo: root should be set by client to nexus or nexus-int or whatever as required
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",
@@ -657,7 +662,8 @@ class ModelScript(KGObject):
 
 
 class EModel(ModelInstance):
-    path = NAMESPACE + "/simulation/emodel/v0.1.1"
+    namespace = NAMESPACE
+    _path = "/simulation/emodel/v0.1.1"
     type = ["prov:Entity", "nsg:EModel"]
     context = [
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",
@@ -717,7 +723,8 @@ class EModel(ModelInstance):
 
 
 class AnalysisResult(KGObject):
-    path = NAMESPACE + "/simulation/analysisresult/v1.0.0"
+    namespace = NAMESPACE
+    _path = "/simulation/analysisresult/v1.0.0"
     type = ["prov:Entity", "nsg:Entity", "nsg:AnalysisResult"]
     context =  [
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",
@@ -825,7 +832,8 @@ class AnalysisResult(KGObject):
 
 class ValidationTestDefinition(KGObject, HasAliasMixin):
     """docstring"""
-    path = NAMESPACE + "/simulation/validationtestdefinition/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/simulation/validationtestdefinition/v0.1.0"
     #path = NAMESPACE + "/simulation/validationtestdefinition/v0.1.2"
     type = ["prov:Entity", "nsg:ValidationTestDefinition"]
     context = [
@@ -977,7 +985,8 @@ class ValidationTestDefinition(KGObject, HasAliasMixin):
 
 class ValidationScript(KGObject):  # or ValidationImplementation
     """docstring"""
-    path = NAMESPACE + "/simulation/validationscript/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/simulation/validationscript/v0.1.0"
     type = ["prov:Entity", "nsg:ModelValidationScript"]
     context = [
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",
@@ -1066,7 +1075,8 @@ class ValidationScript(KGObject):  # or ValidationImplementation
 
 class ValidationResult(KGObject):
     """docstring"""
-    path = NAMESPACE + "/simulation/validationresult/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/simulation/validationresult/v0.1.0"
     #path = NAMESPACE + "/simulation/validationresult/v0.1.1"
     type = ["prov:Entity", "nsg:ValidationResult"]
     context = [
@@ -1163,7 +1173,8 @@ class ValidationResult(KGObject):
 
 class ValidationActivity(KGObject):
     """docstring"""
-    path = NAMESPACE + "/simulation/modelvalidation/v0.2.0"
+    namespace = NAMESPACE
+    _path = "/simulation/modelvalidation/v0.2.0"
     type = ["prov:Activity", "nsg:ModelValidation"]
     context = [
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",

--- a/fairgraph/brainsimulation.py
+++ b/fairgraph/brainsimulation.py
@@ -19,9 +19,7 @@ from .core import Organization, Person, Age
 logger = logging.getLogger("fairgraph")
 mimetypes.init()
 
-#NAMESPACE = "neuralactivity"
-NAMESPACE = "modelvalidation"
-#NAMESPACE = "brainsimulation"
+DEFAULT_NAMESPACE = "modelvalidation"
 
 ATTACHMENT_SIZE_LIMIT = 1024 * 1024  # 1 MB
 
@@ -43,9 +41,9 @@ class HasAliasMixin(object):
 
 class ModelProject(KGObject, HasAliasMixin):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/modelproject/v0.1.0"
-    #path = NAMESPACE + "/simulation/modelproject/v0.1.1"
+    #path = DEFAULT_NAMESPACE + "/simulation/modelproject/v0.1.1"
     type = ["prov:Entity", "nsg:ModelProject"]
 
     context = {
@@ -314,8 +312,8 @@ class ModelProject(KGObject, HasAliasMixin):
 
 class ModelInstance(KGObject):
     """docstring"""
-    #path = NAMESPACE + "/simulation/modelinstance/v0.1.2"
-    namespace = NAMESPACE
+    #path = DEFAULT_NAMESPACE + "/simulation/modelinstance/v0.1.2"
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/modelinstance/v0.1.1"
     type = ["prov:Entity", "nsg:ModelInstance"]
     # ScientificModelInstance
@@ -433,7 +431,7 @@ class ModelInstance(KGObject):
 
 class MEModel(ModelInstance):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/memodel/v0.1.2"  # latest is 0.1.4, but all the data is currently under 0.1.2
     type = ["prov:Entity", "nsg:MEModel", "nsg:ModelInstance"]
     context = [
@@ -540,7 +538,7 @@ class MEModel(ModelInstance):
 
 
 class Morphology(KGObject):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/morphology/v0.1.1"
     type = ["prov:Entity", "nsg:Morphology"]
     context = [
@@ -603,7 +601,7 @@ class Morphology(KGObject):
 
 
 class ModelScript(KGObject):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/emodelscript/v0.1.0"
     type = ["prov:Entity", "nsg:EModelScript"]  # generalize to other sub-types of script
     context =  [  # todo: root should be set by client to nexus or nexus-int or whatever as required
@@ -662,7 +660,7 @@ class ModelScript(KGObject):
 
 
 class EModel(ModelInstance):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/emodel/v0.1.1"
     type = ["prov:Entity", "nsg:EModel"]
     context = [
@@ -723,7 +721,7 @@ class EModel(ModelInstance):
 
 
 class AnalysisResult(KGObject):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/analysisresult/v1.0.0"
     type = ["prov:Entity", "nsg:Entity", "nsg:AnalysisResult"]
     context =  [
@@ -832,9 +830,9 @@ class AnalysisResult(KGObject):
 
 class ValidationTestDefinition(KGObject, HasAliasMixin):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/validationtestdefinition/v0.1.0"
-    #path = NAMESPACE + "/simulation/validationtestdefinition/v0.1.2"
+    #path = DEFAULT_NAMESPACE + "/simulation/validationtestdefinition/v0.1.2"
     type = ["prov:Entity", "nsg:ValidationTestDefinition"]
     context = [
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",
@@ -985,7 +983,7 @@ class ValidationTestDefinition(KGObject, HasAliasMixin):
 
 class ValidationScript(KGObject):  # or ValidationImplementation
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/validationscript/v0.1.0"
     type = ["prov:Entity", "nsg:ModelValidationScript"]
     context = [
@@ -1075,9 +1073,9 @@ class ValidationScript(KGObject):  # or ValidationImplementation
 
 class ValidationResult(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/validationresult/v0.1.0"
-    #path = NAMESPACE + "/simulation/validationresult/v0.1.1"
+    #path = DEFAULT_NAMESPACE + "/simulation/validationresult/v0.1.1"
     type = ["prov:Entity", "nsg:ValidationResult"]
     context = [
         "{{base}}/contexts/neurosciencegraph/core/data/v0.3.1",
@@ -1173,7 +1171,7 @@ class ValidationResult(KGObject):
 
 class ValidationActivity(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/simulation/modelvalidation/v0.2.0"
     type = ["prov:Activity", "nsg:ModelValidation"]
     context = [
@@ -1260,3 +1258,15 @@ class ValidationActivity(KGObject):
                 "@id": self.result.id
             }
         return data
+
+
+def list_kg_classes():
+    """List all KG classes defined in this module"""
+    return [obj for name, obj in inspect.getmembers(sys.modules[__name__])
+            if inspect.isclass(obj) and issubclass(obj, KGObject) and obj.__module__ == __name__]
+
+
+def use_namespace(namespace):
+    """Set the namespace for all classes in this module."""
+    for cls in list_kg_classes():
+        cls.namespace = namespace

--- a/fairgraph/core.py
+++ b/fairgraph/core.py
@@ -4,21 +4,23 @@ core
 """
 
 from __future__ import unicode_literals
+import sys, inspect
 import logging
 from .base import KGObject, KGProxy, KGQuery, cache, as_list
 from .errors import ResourceExistsError
 from .commons import Address, Species, Strain, Sex, Age, QuantitativeValue
 
-NAMESPACE = "neuralactivity"
-#NAMESPACE = "neurosciencegraph"
-#NAMESPACE = "brainsimulation"
+DEFAULT_NAMESPACE = None
+# core is used everywhere, so it makes no sense to set a default namespace
+# the namespace to be used in a given context should be set using "use_namespace()"
+
 
 logger = logging.getLogger("fairgraph")
 
 
 class Subject(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/core/subject/v0.1.2"
     type = ["nsg:Subject", "prov:Entity"]
     context = {
@@ -92,7 +94,7 @@ class Subject(KGObject):
 
 class Organization(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path =  "/core/organization/v0.1.0"
     type = "nsg:Organization"
     context = {
@@ -156,7 +158,7 @@ class Organization(KGObject):
 
 class Person(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/core/person/v0.1.0"
     type = ["nsg:Person", "prov:Agent"]
     context = {
@@ -274,7 +276,7 @@ class Person(KGObject):
 
 
 class Protocol(KGObject):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/core/protocol/v0.1.0"
     type = ["nsg:Protocol", "prov:Entity"]
     context = {
@@ -386,7 +388,7 @@ class Material(object):
 
 class Collection(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/core/collection/v0.1.0"
     type = ["nsg:Collection", "prov:Entity"]
     context = {
@@ -438,3 +440,15 @@ class Collection(KGObject):
             "@id": member.id
         } for member in as_list(self.members)]
         return data
+
+
+def list_kg_classes():
+    """List all KG classes defined in this module"""
+    return [obj for name, obj in inspect.getmembers(sys.modules[__name__])
+            if inspect.isclass(obj) and issubclass(obj, KGObject) and obj.__module__ == __name__]
+
+
+def use_namespace(namespace):
+    """Set the namespace for all classes in this module."""
+    for cls in list_kg_classes():
+        cls.namespace = namespace

--- a/fairgraph/core.py
+++ b/fairgraph/core.py
@@ -18,7 +18,8 @@ logger = logging.getLogger("fairgraph")
 
 class Subject(KGObject):
     """docstring"""
-    path = NAMESPACE + "/core/subject/v0.1.2"
+    namespace = NAMESPACE
+    _path = "/core/subject/v0.1.2"
     type = ["nsg:Subject", "prov:Entity"]
     context = {
         "schema": "http://schema.org/",
@@ -91,7 +92,8 @@ class Subject(KGObject):
 
 class Organization(KGObject):
     """docstring"""
-    path = NAMESPACE + "/core/organization/v0.1.0"
+    namespace = NAMESPACE
+    _path =  "/core/organization/v0.1.0"
     type = "nsg:Organization"
     context = {
         "schema": "http://schema.org/",
@@ -154,7 +156,8 @@ class Organization(KGObject):
 
 class Person(KGObject):
     """docstring"""
-    path = NAMESPACE + "/core/person/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/core/person/v0.1.0"
     type = ["nsg:Person", "prov:Agent"]
     context = {
         "schema": "http://schema.org/",
@@ -271,7 +274,8 @@ class Person(KGObject):
 
 
 class Protocol(KGObject):
-    path = NAMESPACE + "/core/protocol/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/core/protocol/v0.1.0"
     type = ["nsg:Protocol", "prov:Entity"]
     context = {
         "schema": "http://schema.org/",
@@ -337,7 +341,8 @@ class Protocol(KGObject):
 
 
 class Identifier(KGObject):
-    path = "nexus/schemaorgsh/identifier/v0.1.0/"
+    namespace = "nexus"
+    _path = "/schemaorgsh/identifier/v0.1.0/"
     type = "schema:Identifier"
 
 
@@ -381,7 +386,8 @@ class Material(object):
 
 class Collection(KGObject):
     """docstring"""
-    path = NAMESPACE + "/core/collection/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/core/collection/v0.1.0"
     type = ["nsg:Collection", "prov:Entity"]
     context = {
         "schema": "http://schema.org/",

--- a/fairgraph/data.py
+++ b/fairgraph/data.py
@@ -52,7 +52,8 @@ class DataObject(KGObject):
 
 
 class FileAssociation(DataObject):
-    path = "cscs/core/fileassociation/v1.0.0"
+    namespace = "cscs"
+    _path = "/core/fileassociation/v1.0.0"
     type = ["cscs:Fileassociation", "https://schema.hbp.eu/LinkingInstance"]
     property_names = ["name", "from", "to"]
 
@@ -66,7 +67,8 @@ class FileAssociation(DataObject):
 
 
 class CSCSFile(DataObject):
-    path = "cscs/core/file/v1.0.0"
+    namespace = "cscs"
+    _path = "/core/file/v1.0.0"
     type = ["cscs:File"]
     property_names = ["name", "absolute_path", "byte_size", "content_type",
                       "last_modified", "relative_path"]

--- a/fairgraph/electrophysiology.py
+++ b/fairgraph/electrophysiology.py
@@ -118,7 +118,8 @@ class Trace(KGObject):
 
 class MultiChannelMultiTrialRecording(Trace):
     """docstring"""
-    path = NAMESPACE + "/electrophysiology/multitrace/v0.1.0"  # for nexus
+    namespace = NAMESPACE
+    _path =  "/electrophysiology/multitrace/v0.1.0"  # for nexus
     #path = NAMESPACE + "/electrophysiology/multitrace/v0.3.0"  # for nexus-int
     type = ["prov:Entity", "nsg:MultiChannelMultiTrialRecording"]
 
@@ -829,7 +830,7 @@ class PatchClampExperiment(KGObject):
         return data
 
 
-class QualifiedGeneration(KGObject):
+class QualifiedTraceGeneration(KGObject):
     namespace = NAMESPACE
     _path = "/electrophysiology/tracegeneration/v0.1.0"
     type = ["prov:Generation", "nsg:TraceGeneration"]
@@ -887,7 +888,8 @@ class QualifiedGeneration(KGObject):
 
 
 class QualifiedMultiTraceGeneration(KGObject):
-    path = NAMESPACE + "/electrophysiology/multitracegeneration/v0.1.0" # for nexus
+    namespace = NAMESPACE
+    _path = "/electrophysiology/multitracegeneration/v0.1.0" # for nexus
     #path = NAMESPACE + "/electrophysiology/multitracegeneration/v0.2.0"  # for nexus-int
     type = ["prov:Generation", "nsg:MultiTraceGeneration"]
     context = {

--- a/fairgraph/electrophysiology.py
+++ b/fairgraph/electrophysiology.py
@@ -16,7 +16,8 @@ NAMESPACE = "neuralactivity"
 
 class Trace(KGObject):
     """docstring"""
-    path = NAMESPACE + "/electrophysiology/trace/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/electrophysiology/trace/v0.1.0"
     # v1.0.0 now exists - check differences
     type = ["prov:Entity", "nsg:Trace"]
     context = {
@@ -190,7 +191,8 @@ class MultiChannelMultiTrialRecording(Trace):
 
 class PatchedCell(KGObject):
     """docstring"""
-    path = NAMESPACE + "/experiment/patchedcell/v0.1.0"  # latest 0.2.1
+    namespace = NAMESPACE
+    _path = "/experiment/patchedcell/v0.1.0"  # latest 0.2.1
     type = ["nsg:PatchedCell", "prov:Entity"]
     collection_class = "PatchedCellCollection"
     experiment_class = "PatchClampExperiment"
@@ -356,7 +358,8 @@ class PatchedCell(KGObject):
 
 class Slice(KGObject):  # should move to "core" module?
     """docstring"""
-    path = NAMESPACE + "/core/slice/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/core/slice/v0.1.0"
     type = ["nsg:Slice", "prov:Entity"]
     context = {
         "schema": "http://schema.org/",
@@ -419,7 +422,8 @@ class Slice(KGObject):  # should move to "core" module?
 
 class BrainSlicingActivity(KGObject):
     """docstring"""
-    path = NAMESPACE + "/experiment/brainslicing/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/experiment/brainslicing/v0.1.0"
     type = ["nsg:BrainSlicing", "prov:Activity"]
     context = {
         "schema": "http://schema.org/",
@@ -547,7 +551,8 @@ class BrainSlicingActivity(KGObject):
 
 class PatchedSlice(KGObject):
     """docstring"""
-    path = NAMESPACE + "/experiment/patchedslice/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/experiment/patchedslice/v0.1.0"
     type = ["nsg:PatchedSlice", "prov:Entity"]
     context = {
         "schema": "http://schema.org/",
@@ -615,7 +620,8 @@ class PatchedSlice(KGObject):
 
 class PatchedCellCollection(KGObject):
     """docstring"""
-    path = NAMESPACE + "/experiment/patchedcellcollection/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/experiment/patchedcellcollection/v0.1.0"
     type = ["nsg:Collection"]
     context = {
         "schema": "http://schema.org/",
@@ -682,7 +688,8 @@ class PatchedCellCollection(KGObject):
 
 class PatchClampActivity(KGObject):  # rename to "PatchClampRecording"?
     """docstring"""
-    path = NAMESPACE + "/experiment/wholecellpatchclamp/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/experiment/wholecellpatchclamp/v0.1.0"
     type = ["nsg:WholeCellPatchClamp", "prov:Activity"]
     generates_class = "PatchedSlice"
     context = {
@@ -757,7 +764,8 @@ class PatchClampActivity(KGObject):  # rename to "PatchClampRecording"?
 
 class PatchClampExperiment(KGObject):
     """docstring"""
-    path = NAMESPACE + "/electrophysiology/stimulusexperiment/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/electrophysiology/stimulusexperiment/v0.1.0"
     type = ["nsg:StimulusExperiment", "prov:Activity"]
     context = {
         "schema": "http://schema.org/",
@@ -821,8 +829,9 @@ class PatchClampExperiment(KGObject):
         return data
 
 
-class QualifiedTraceGeneration(KGObject):
-    path = NAMESPACE + "/electrophysiology/tracegeneration/v0.1.0"
+class QualifiedGeneration(KGObject):
+    namespace = NAMESPACE
+    _path = "/electrophysiology/tracegeneration/v0.1.0"
     type = ["prov:Generation", "nsg:TraceGeneration"]
     context = {
         "schema": "http://schema.org/",
@@ -935,26 +944,30 @@ class QualifiedMultiTraceGeneration(KGObject):
 
 
 class IntraCellularSharpElectrodeRecordedCell(PatchedCell):
-    path = NAMESPACE + "/experiment/intrasharprecordedcell/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/experiment/intrasharprecordedcell/v0.1.0"
     type = ["nsg:IntraCellularSharpElectrodeRecordedCell", "prov:Entity"]
     collection_class = "IntraCellularSharpElectrodeRecordedCellCollection"
     experiment_class = "IntraCellularSharpElectrodeExperiment"
 
 class IntraCellularSharpElectrodeRecording(PatchClampActivity):
-    path = NAMESPACE + "/experiment/intrasharpelectrode/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/experiment/intrasharpelectrode/v0.1.0"
     type = ["nsg:IntraCellularSharpElectrode", "prov:Activity"]
     generates_class = "IntraCellularSharpElectrodeRecordedSlice"
 
 
 class IntraCellularSharpElectrodeRecordedCellCollection(PatchedCellCollection):
-    path = NAMESPACE + "/experiment/intrasharprecordedcellcollection/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/experiment/intrasharprecordedcellcollection/v0.1.0"
     type = ["nsg:Collection"]
     member_class = "IntraCellularSharpElectrodeRecordedCell"
     recorded_from_class = "IntraCellularSharpElectrodeRecordedSlice"
 
 
 class IntraCellularSharpElectrodeRecordedSlice(PatchedSlice):
-    path = NAMESPACE + "/experiment/intrasharprecordedslice/v0.1.0"
+    namespace = NAMESPACE
+    _path = "/experiment/intrasharprecordedslice/v0.1.0"
     type = ["nsg:IntraCellularSharpElectrodeRecordedSlice", "prov:Entity"]
     collection_class = "IntraCellularSharpElectrodeRecordedCellCollection"
     recording_activity_class = "IntraCellularSharpElectrodeRecording"
@@ -962,6 +975,7 @@ class IntraCellularSharpElectrodeRecordedSlice(PatchedSlice):
 
 class IntraCellularSharpElectrodeExperiment(PatchClampExperiment):
     """docstring"""
-    path = NAMESPACE + "/electrophysiology/stimulusexperiment/v0.1.0"  # to fix
+    namespace = NAMESPACE
+    _path = "/electrophysiology/stimulusexperiment/v0.1.0"  # to fix
     type = ["nsg:StimulusExperiment", "prov:Activity"]
     recorded_cell_class = "IntraCellularSharpElectrodeRecordedCell"

--- a/fairgraph/electrophysiology.py
+++ b/fairgraph/electrophysiology.py
@@ -3,20 +3,19 @@ electrophysiology
 
 """
 
+import sys, inspect
 from .base import KGObject, KGProxy, KGQuery, cache, lookup, build_kg_object
 from .commons import QuantitativeValue, BrainRegion, CellType
 from .core import Subject, Person
 from .minds import Dataset
 
 
-NAMESPACE = "neuralactivity"
-#NAMESPACE = "neurosciencegraph"
-#NAMESPACE = "brainsimulation"
+DEFAULT_NAMESPACE = "neuralactivity"
 
 
 class Trace(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/electrophysiology/trace/v0.1.0"
     # v1.0.0 now exists - check differences
     type = ["prov:Entity", "nsg:Trace"]
@@ -118,9 +117,9 @@ class Trace(KGObject):
 
 class MultiChannelMultiTrialRecording(Trace):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path =  "/electrophysiology/multitrace/v0.1.0"  # for nexus
-    #path = NAMESPACE + "/electrophysiology/multitrace/v0.3.0"  # for nexus-int
+    #path = DEFAULT_NAMESPACE + "/electrophysiology/multitrace/v0.3.0"  # for nexus-int
     type = ["prov:Entity", "nsg:MultiChannelMultiTrialRecording"]
 
     def __init__(self, name, data_location, generated_by, generation_metadata, channel_names,
@@ -192,7 +191,7 @@ class MultiChannelMultiTrialRecording(Trace):
 
 class PatchedCell(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/patchedcell/v0.1.0"  # latest 0.2.1
     type = ["nsg:PatchedCell", "prov:Entity"]
     collection_class = "PatchedCellCollection"
@@ -359,7 +358,7 @@ class PatchedCell(KGObject):
 
 class Slice(KGObject):  # should move to "core" module?
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/core/slice/v0.1.0"
     type = ["nsg:Slice", "prov:Entity"]
     context = {
@@ -423,7 +422,7 @@ class Slice(KGObject):  # should move to "core" module?
 
 class BrainSlicingActivity(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/brainslicing/v0.1.0"
     type = ["nsg:BrainSlicing", "prov:Activity"]
     context = {
@@ -552,7 +551,7 @@ class BrainSlicingActivity(KGObject):
 
 class PatchedSlice(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/patchedslice/v0.1.0"
     type = ["nsg:PatchedSlice", "prov:Entity"]
     context = {
@@ -621,7 +620,7 @@ class PatchedSlice(KGObject):
 
 class PatchedCellCollection(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/patchedcellcollection/v0.1.0"
     type = ["nsg:Collection"]
     context = {
@@ -689,7 +688,7 @@ class PatchedCellCollection(KGObject):
 
 class PatchClampActivity(KGObject):  # rename to "PatchClampRecording"?
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/wholecellpatchclamp/v0.1.0"
     type = ["nsg:WholeCellPatchClamp", "prov:Activity"]
     generates_class = "PatchedSlice"
@@ -765,7 +764,7 @@ class PatchClampActivity(KGObject):  # rename to "PatchClampRecording"?
 
 class PatchClampExperiment(KGObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/electrophysiology/stimulusexperiment/v0.1.0"
     type = ["nsg:StimulusExperiment", "prov:Activity"]
     context = {
@@ -831,7 +830,7 @@ class PatchClampExperiment(KGObject):
 
 
 class QualifiedTraceGeneration(KGObject):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/electrophysiology/tracegeneration/v0.1.0"
     type = ["prov:Generation", "nsg:TraceGeneration"]
     context = {
@@ -888,9 +887,9 @@ class QualifiedTraceGeneration(KGObject):
 
 
 class QualifiedMultiTraceGeneration(KGObject):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/electrophysiology/multitracegeneration/v0.1.0" # for nexus
-    #path = NAMESPACE + "/electrophysiology/multitracegeneration/v0.2.0"  # for nexus-int
+    #path = DEFAULT_NAMESPACE + "/electrophysiology/multitracegeneration/v0.2.0"  # for nexus-int
     type = ["prov:Generation", "nsg:MultiTraceGeneration"]
     context = {
         "schema": "http://schema.org/",
@@ -946,21 +945,21 @@ class QualifiedMultiTraceGeneration(KGObject):
 
 
 class IntraCellularSharpElectrodeRecordedCell(PatchedCell):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/intrasharprecordedcell/v0.1.0"
     type = ["nsg:IntraCellularSharpElectrodeRecordedCell", "prov:Entity"]
     collection_class = "IntraCellularSharpElectrodeRecordedCellCollection"
     experiment_class = "IntraCellularSharpElectrodeExperiment"
 
 class IntraCellularSharpElectrodeRecording(PatchClampActivity):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/intrasharpelectrode/v0.1.0"
     type = ["nsg:IntraCellularSharpElectrode", "prov:Activity"]
     generates_class = "IntraCellularSharpElectrodeRecordedSlice"
 
 
 class IntraCellularSharpElectrodeRecordedCellCollection(PatchedCellCollection):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/intrasharprecordedcellcollection/v0.1.0"
     type = ["nsg:Collection"]
     member_class = "IntraCellularSharpElectrodeRecordedCell"
@@ -968,7 +967,7 @@ class IntraCellularSharpElectrodeRecordedCellCollection(PatchedCellCollection):
 
 
 class IntraCellularSharpElectrodeRecordedSlice(PatchedSlice):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/experiment/intrasharprecordedslice/v0.1.0"
     type = ["nsg:IntraCellularSharpElectrodeRecordedSlice", "prov:Entity"]
     collection_class = "IntraCellularSharpElectrodeRecordedCellCollection"
@@ -977,7 +976,19 @@ class IntraCellularSharpElectrodeRecordedSlice(PatchedSlice):
 
 class IntraCellularSharpElectrodeExperiment(PatchClampExperiment):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/electrophysiology/stimulusexperiment/v0.1.0"  # to fix
     type = ["nsg:StimulusExperiment", "prov:Activity"]
     recorded_cell_class = "IntraCellularSharpElectrodeRecordedCell"
+
+
+def list_kg_classes():
+    """List all KG classes defined in this module"""
+    return [obj for name, obj in inspect.getmembers(sys.modules[__name__])
+            if inspect.isclass(obj) and issubclass(obj, KGObject) and obj.__module__ == __name__]
+
+
+def use_namespace(namespace):
+    """Set the namespace for all classes in this module."""
+    for cls in list_kg_classes():
+        cls.namespace = namespace

--- a/fairgraph/minds.py
+++ b/fairgraph/minds.py
@@ -8,6 +8,7 @@ from fairgraph.data import FileAssociation, CSCSFile
 
 class MINDSObject(KGObject):
     """docstring"""
+    namespace = "minds"
     context = [
         "{{base}}/contexts/nexus/core/resource/v0.3.0",
         {
@@ -100,7 +101,7 @@ class MINDSObject(KGObject):
 
 class Dataset(MINDSObject):
     """docstring"""
-    path = "minds/core/dataset/v1.0.0"
+    _path = "/core/dataset/v1.0.0"
     #type = ["https://schema.hbp.eu/Dataset"]
     type = ["minds:Dataset"]
     property_names = ["activity", "component", "contributors", "created_at", "datalink",
@@ -111,7 +112,7 @@ class Dataset(MINDSObject):
 
 class Activity(MINDSObject):
     """docstring"""
-    path = "minds/core/dataset/v1.0.0"
+    _path = "/core/dataset/v1.0.0"
     #type = ["https://schema.hbp.eu/Activity"]
     type = ["minds:Activity"]
     property_names = ["created_at", "ethics", "methods", "preparation", "protocols",
@@ -120,7 +121,7 @@ class Activity(MINDSObject):
 
 class Method(MINDSObject):
     """docstring"""
-    path = "minds/experiment/method/v1.0.0"
+    _path = "/experiment/method/v1.0.0"
     #type = ["https://schema.hbp.eu/ExperimentMethod"]
     type = ["minds:ExperimentMethod"]
     property_names = ["name", "associated_with"]
@@ -128,7 +129,7 @@ class Method(MINDSObject):
 
 class SpecimenGroup(MINDSObject):
     """docstring"""
-    path = "minds/core/specimengroup/v1.0.0"
+    _path = "/core/specimengroup/v1.0.0"
     type = ["minds:SpecimenGroup"]
     property_names = ["created_at", "subjects", "name", "associated_with"]
 
@@ -137,7 +138,7 @@ class MINDSSubject(MINDSObject):
     """docstring"""
     # name qualified to avoid clash with nsg:Subject
     # pending addition of namespaces to registry
-    path = "minds/experiment/subject/v1.0.0"
+    _path = "/experiment/subject/v1.0.0"
     #type = ["https://schema.hbp.eu/ExperimentSubject"]
     type = ["minds:ExperimentSubject"]
     property_names = ["age", "age_category", "causeOfDeath", "samples", "sex", "species",
@@ -153,7 +154,7 @@ class License(MINDSObject):
 
 class EmbargoStatus(MINDSObject):
     """docstring"""
-    path = "minds/core/embargostatus/v1.0.0"
+    _path = "/core/embargostatus/v1.0.0"
     #type = ["https://schema.hbp.eu/EmbargoStatus"]
     type = ["minds:EmbargoStatus"]
     property_names = ["name", "associated_with"]
@@ -161,7 +162,7 @@ class EmbargoStatus(MINDSObject):
 
 class Sample(MINDSObject):
     """docstring"""
-    path = "minds/experiment/sample/v1.0.0"
+    _path = "/experiment/sample/v1.0.0"
     #type = ["https://schema.hbp.eu/ExperimentSample"]
     type = ["minds:ExperimentSample"]
     property_names = ["name", "methods", "parcellationAtlas", "parcellationRegion",
@@ -183,14 +184,14 @@ class Sample(MINDSObject):
 
 class Person(MINDSObject):
     """docstring"""
-    path = "minds/core/person/v1.0.0"
+    _path = "/core/person/v1.0.0"
     type = ["minds:Person"]
     property_names = ["name"]
 
 
 class PLAComponent(MINDSObject):
     """docstring"""
-    path = "minds/core/placomponent/v1.0.0"
+    _path = "/core/placomponent/v1.0.0"
     type = ["minds:PLAComponent"]
     property_names = ["name", "description"]
 
@@ -208,25 +209,25 @@ class PLAComponent(MINDSObject):
 
 
 class AgeCategory(MINDSObject):
-    path = "minds/core/agecategory/v1.0.0"
+    _path = "/core/agecategory/v1.0.0"
     type = ["minds:Agecategory"]
     property_names = ["name"]
 
 
 class Sex(MINDSObject):
-    path = "minds/core/sex/v1.0.0"
+    _path = "/core/sex/v1.0.0"
     type = ["minds:Sex"]
     property_names = ["name"]
 
 
 class Species(MINDSObject):
-    path = "minds/core/species/v1.0.0"
+    _path = "/core/species/v1.0.0"
     type = ["minds:Species"]
     property_names = ["name"]
 
 
 class ParcellationRegion(MINDSObject):
-    path = "minds/core/parcellationregion/v1.0.0"
+    _path = "/core/parcellationregion/v1.0.0"
     type = ["minds:Parcellationregion"]
     property_names = ["name"]
 

--- a/fairgraph/neuromorphic.py
+++ b/fairgraph/neuromorphic.py
@@ -1,0 +1,8 @@
+
+
+
+
+class Simulation
+
+
+class HardwareSystem, HardwareConfiguration, ComputingEnvironment, ScriptedModelInstance

--- a/fairgraph/software.py
+++ b/fairgraph/software.py
@@ -45,7 +45,8 @@ class ProgrammingLanguage(OntologyTerm):
 
 
 class Software(KGObject):
-    path = NAMESPACE + "/software/software/v0.1.1"
+    namespace = NAMESPACE
+    _path = "/software/software/v0.1.1"
     type = ["prov:Entity", "nsg:Software"]
 
     context = {

--- a/fairgraph/software.py
+++ b/fairgraph/software.py
@@ -11,7 +11,7 @@ from .commons import License
 
 logger = logging.getLogger("fairgraph")
 
-NAMESPACE = "softwarecatalog"
+DEFAULT_NAMESPACE = "softwarecatalog"
 
 
 class SoftwareCategory(OntologyTerm):
@@ -45,7 +45,7 @@ class ProgrammingLanguage(OntologyTerm):
 
 
 class Software(KGObject):
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/software/software/v0.1.1"
     type = ["prov:Entity", "nsg:Software"]
 
@@ -228,3 +228,15 @@ class Software(KGObject):
         if self.help:
             data["schema:softwareHelp"] = {"@id": self.help}
         return data
+
+
+def list_kg_classes():
+    """List all KG classes defined in this module"""
+    return [obj for name, obj in inspect.getmembers(sys.modules[__name__])
+            if inspect.isclass(obj) and issubclass(obj, KGObject) and obj.__module__ == __name__]
+
+
+def use_namespace(namespace):
+    """Set the namespace for all classes in this module."""
+    for cls in list_kg_classes():
+        cls.namespace = namespace

--- a/fairgraph/uniminds.py
+++ b/fairgraph/uniminds.py
@@ -2,7 +2,7 @@
 
 from .minds import MINDSObject
 
-NAMESPACE = "uniminds"
+DEFAULT_NAMESPACE = "uniminds"
 
 # options
 "https://kg.humanbrainproject.org/query/uniminds/options/abstractionlevel/v1.0.0/abstractionLevel/instances"
@@ -10,7 +10,7 @@ NAMESPACE = "uniminds"
 
 class ModelRelease(MINDSObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/core/modelinstance/v1.0.0"
     type = ["uniminds:Modelinstance"]
     property_names = ["identifier", "name", "description", "version",
@@ -25,7 +25,7 @@ class ModelRelease(MINDSObject):
 
 class FileBundle(MINDSObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/core/filebundle/v1.0.0"
     type = ["uniminds:FileBundle"]
     property_names = ["identifier", "name", "description", "url", "usageNotes", "modelInstance"]
@@ -37,7 +37,7 @@ class FileBundle(MINDSObject):
 
 class Person(MINDSObject):
     """docstring"""
-    namespace = NAMESPACE
+    namespace = DEFAULT_NAMESPACE
     _path = "/core/person/v1.0.0"
     type = ["uniminds:Person"]
     property_names = ["name", "familyName", "givenName", "email", "identifier"] # "orcid"

--- a/fairgraph/uniminds.py
+++ b/fairgraph/uniminds.py
@@ -2,7 +2,7 @@
 
 from .minds import MINDSObject
 
-
+NAMESPACE = "uniminds"
 
 # options
 "https://kg.humanbrainproject.org/query/uniminds/options/abstractionlevel/v1.0.0/abstractionLevel/instances"
@@ -10,7 +10,8 @@ from .minds import MINDSObject
 
 class ModelRelease(MINDSObject):
     """docstring"""
-    path = "uniminds/core/modelinstance/v1.0.0"
+    namespace = NAMESPACE
+    _path = "/core/modelinstance/v1.0.0"
     type = ["uniminds:Modelinstance"]
     property_names = ["identifier", "name", "description", "version",
                       "abstractionLevel", "brainStructure", "cellularTarget",
@@ -24,7 +25,8 @@ class ModelRelease(MINDSObject):
 
 class FileBundle(MINDSObject):
     """docstring"""
-    path = "uniminds/core/filebundle/v1.0.0"
+    namespace = NAMESPACE
+    _path = "/core/filebundle/v1.0.0"
     type = ["uniminds:FileBundle"]
     property_names = ["identifier", "name", "description", "url", "usageNotes", "modelInstance"]
 
@@ -35,7 +37,8 @@ class FileBundle(MINDSObject):
 
 class Person(MINDSObject):
     """docstring"""
-    path = "uniminds/core/person/v1.0.0"
+    namespace = NAMESPACE
+    _path = "/core/person/v1.0.0"
     type = ["uniminds:Person"]
     property_names = ["name", "familyName", "givenName", "email", "identifier"] # "orcid"
 

--- a/test/test_electrophysiology.py
+++ b/test/test_electrophysiology.py
@@ -6,14 +6,15 @@ which returns data loaded from the files in the test_data directory.
 
 from fairgraph.base import KGQuery, KGProxy, as_list, Distribution
 from fairgraph.commons import BrainRegion, CellType, QuantitativeValue
-from fairgraph.electrophysiology import (BrainSlicingActivity,
-                                         MultiChannelMultiTrialRecording,
-                                         PatchClampActivity,
-                                         PatchClampExperiment, PatchedCell,
-                                         PatchedCellCollection, PatchedSlice,
-                                         QualifiedMultiTraceGeneration,
-                                         QualifiedTraceGeneration, Slice,
-                                         Trace)
+from fairgraph.core import use_namespace as use_core_namespace
+from fairgraph.electrophysiology import (
+    Trace, MultiChannelMultiTrialRecording, PatchedCell, Slice, BrainSlicingActivity,
+    PatchedSlice, PatchedCellCollection, PatchClampActivity, PatchClampExperiment,
+    QualifiedTraceGeneration, QualifiedMultiTraceGeneration,
+    IntraCellularSharpElectrodeExperiment, IntraCellularSharpElectrodeRecordedCell,
+    IntraCellularSharpElectrodeRecordedCellCollection,
+    IntraCellularSharpElectrodeRecordedSlice, IntraCellularSharpElectrodeRecording,
+    list_kg_classes, use_namespace as use_electrophysiology_namespace)
 from fairgraph.minds import Dataset
 
 from .utils import kg_client, MockKGObject, test_data_lookup
@@ -34,6 +35,9 @@ test_data_lookup.update({
     "/v0/data/neuralactivity/electrophysiology/multitracegeneration/v0.1.0/": "test/test_data/electrophysiology/multitracegeneration_list_0_10.json",
     "/v0/data/neuralactivity/experiment/patchedcell/v0.1.0/5ab24291-8dca-4a45-a484-8a8c28d396e2": "test/test_data/electrophysiology/patchedcell_example.json",
 })
+
+use_core_namespace("neuralactivity")
+use_electrophysiology_namespace("neuralactivity")
 
 
 class TestPatchedCell(object):
@@ -185,3 +189,17 @@ def test__QualifiedTraceGeneration(kg_client):
 def test__QualifiedMultiTraceGeneration(kg_client):
     tracegens = QualifiedMultiTraceGeneration.list(kg_client, size=10)
     assert len(tracegens) == 4
+
+
+class TestModuleFunctions(object):
+
+    def test_list_kg_classes(self):
+        expected_classes = set((
+            Trace, MultiChannelMultiTrialRecording, PatchedCell, Slice, BrainSlicingActivity,
+            PatchedSlice, PatchedCellCollection, PatchClampActivity, PatchClampExperiment,
+            QualifiedTraceGeneration, QualifiedMultiTraceGeneration,
+            IntraCellularSharpElectrodeExperiment, IntraCellularSharpElectrodeRecordedCell,
+            IntraCellularSharpElectrodeRecordedCellCollection,
+            IntraCellularSharpElectrodeRecordedSlice, IntraCellularSharpElectrodeRecording
+        ))
+        assert set(list_kg_classes()) == expected_classes


### PR DESCRIPTION
When the same schemas are used in different namespaces (e.g. in "neuralactivity" and "modelvalidation"), this makes it easier to set the appropriate one, e.g.

```
from fairgraph.core import Person
Person.namespace = "modelvalidation"
```

You can also set the namespace for an entire module:
```
from fairgraph import core
core.use_namespace("neuralactivity")
```