### PR TITLE
WIP: encapsulate all metadata about a given field in a single Field object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .vscode
 .coverage
 htmlcov
+*.pyc

--- a/fairgraph/base.py
+++ b/fairgraph/base.py
@@ -6,7 +6,10 @@ import os
 import sys
 from functools import wraps
 from collections import defaultdict
-from collections.abc import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:  # Python 2
+    from collections import Iterable
 import logging
 from uuid import UUID
 from six import with_metaclass

--- a/fairgraph/base.py
+++ b/fairgraph/base.py
@@ -83,22 +83,44 @@ class Field(object):  # playing with an idea, work in progress, not yet used
 
     def __init__(self, name, types, path, required=False, default=None, multiple=False):
         self.name = name
-        self.types = types  # later, may need to use lookup() to turn strings into classes
+        if isinstance(types, (type, str)):
+            self._types = (types,)
+        else:
+            self._types = tuple(types)
+        self._resolved_types = False
+        # later, may need to use lookup() to turn strings into classes
         self.path = path
         self.required = required
         self.default = default
         self.multiple = multiple
 
+    def __repr__(self):
+        return "Field(name='{}', types={}, path='{}', required={}, multiple={})".format(
+            self.name, self._types, self.path, self.required, self.multiple)
+
+    @property
+    def types(self):
+        if not self._resolved_types:
+            self._types = tuple(
+                [lookup(obj) if isinstance(obj, str) else obj
+                 for obj in self._types]
+            )
+            self._resolved_types = True
+        return self._types
+
     def check_value(self, value):
+        def check_single(item):
+            if not isinstance(item, self.types):
+                if not (isinstance(item, (KGProxy, KGQuery)) and item.cls in self.types):
+                    if not isinstance(item, MockKGObject):  # this check could be stricter
+                        raise ValueError("Field '{}' should be of type {}, not {}".format(
+                                         self.name, self.types, type(item)))
         if self.required or value is not None:
             if self.multiple and isinstance(value, Iterable):
                 for item in value:
-                    if not isinstance(item, self.types):
-                        raise ValueError("Field '{}' should be of type {}, not {}".format(
-                                         self.name, self.types, type(item)))
-            elif not isinstance(value, self.types):
-                raise ValueError("Field '{}' should be of type {}, not {}".format(
-                                 self.name, self.types, type(value)))
+                    check_single(item)
+            else:
+                check_single(value)
 
     def intrinsic(self):
         """
@@ -107,12 +129,17 @@ class Field(object):  # playing with an idea, work in progress, not yet used
         """
         return not self.path.startswith("^")
 
-    def serialize(self, value):
+    def serialize(self, value, client):
         def serialize_single(value):
             if isinstance(value, (str, int, float)):
                 return value
             elif hasattr(value, "to_jsonld"):
-                return value.to_jsonld()
+                return value.to_jsonld(client)
+            elif isinstance(value, (KGObject, KGProxy)):
+                return {
+                    "@id": value.id,
+                    "@type": value.type
+                }
         if isinstance(value, (list, tuple)):
             if self.multiple:
                 return [serialize_single(item) for item in value]
@@ -121,29 +148,64 @@ class Field(object):  # playing with an idea, work in progress, not yet used
         else:
             return serialize_single(value)
 
+    def deserialize(self, data, client):
+        if len(self.types) > 1:
+            raise NotImplementedError("todo")
+        #import pdb; pdb.set_trace()
+        if not self.intrinsic:
+            raise NotImplementedError("todo")
+        if issubclass(self.types[0], (KGObject, StructuredMetadata)):
+            return build_kg_object(self.types[0], data)
+        else:
+            return data
+
 
 #class KGObject(object, metaclass=Registry):
 class KGObject(with_metaclass(Registry, object)):
     """Base class for Knowledge Graph objects"""
-    cache = {}
+    object_cache = {}
     save_cache = defaultdict(dict)
+    fields = []
 
     def __init__(self, id=None, instance=None, **properties):
-        for key, value in properties.items():
-            if key not in self.property_names:
-                raise TypeError("{self.__class__.__name__} got an unexpected keyword argument '{key}'".format(self=self, key=key))
-            else:
-                setattr(self, key, value)
+        for field in self.fields:
+            try:
+                value = properties[field.name]
+            except KeyError:
+                if field.required:
+                    raise ValueError("Field '{}' is required.".format(field.name))
+            field.check_value(value)
+            setattr(self, field.name, value)
+
+        # for key, value in properties.items():
+        #     if key not in self.property_names:
+        #         raise TypeError("{self.__class__.__name__} got an unexpected keyword argument '{key}'".format(self=self, key=key))
+
         self.id = id
         self.instance = instance
 
     def __repr__(self):
-        return ('{self.__class__.__name__}('
-                '{self.name!r} {self.id!r})'.format(self=self))
+        if self.fields:
+            template_parts = ("{}={{self.{}!r}}".format(field.name, field.name)
+                                for field in self.fields if getattr(self, field.name) is not None)
+            template = "{self.__class__.__name__}(" + ", ".join(template_parts) + ", id={self.id})"
+            return template.format(self=self)
+        else:  # temporary, while converting all classes to use fields
+            return ('{self.__class__.__name__}('
+                    '{self.name!r} {self.id!r})'.format(self=self))
 
     @classmethod
-    def from_kg_instance(self, instance, client, use_cache=True):
-        raise NotImplementedError("To be implemented by child class")
+    def from_kg_instance(cls, instance, client, use_cache=True):
+        if cls.fields:
+            D = instance.data
+            for otype in cls.type:
+                assert otype in D["@type"]
+            args = {}
+            for field in cls.fields:
+                args[field.name] = field.deserialize(D.get(field.path), client)
+            return cls(id=D["@id"], instance=instance, **args)
+        else:
+            raise NotImplementedError("To be implemented by child class")
 
     @classmethod
     def from_uri(cls, uri, client, use_cache=True, deprecated=False):
@@ -264,7 +326,17 @@ class KGObject(with_metaclass(Registry, object)):
         return False
 
     def _build_data(self, client):
-        raise NotImplementedError("to be implemented by child classes")
+        if self.fields:
+            data = {}
+            for field in self.fields:
+                if field.intrinsic:
+                    value = getattr(self, field.name)
+                    print(field.name, value)
+                    if field.required or value is not None:
+                        data[field.path] = field.serialize(value, client)
+            return data
+        else:
+            raise NotImplementedError("to be implemented by child classes")
 
     def save(self, client):
         """docstring"""
@@ -294,7 +366,7 @@ class KGObject(with_metaclass(Registry, object)):
             instance = client.create_new_instance(self.__class__.path, data)
             self.id = instance.data["@id"]
             self.instance = instance
-            KGObject.cache[self.id] = self
+            KGObject.object_cache[self.id] = self
             KGObject.save_cache[self.__class__][generate_cache_key(self._existence_query)] = self.id
 
     def delete(self, client):
@@ -319,22 +391,39 @@ class KGObject(with_metaclass(Registry, object)):
         return self
 
 
+class MockKGObject(KGObject):
+    """Mock version of KGObject, useful for testing."""
+
+    def __init__(self, id, type):
+        self.id = id
+        self.type = type
+
+    def __repr__(self):
+        return 'MockKGObject({}, {})'.format(self.type, self.id)
+
+
 def cache(f):
     @wraps(f)
     def wrapper(cls, instance, client, use_cache=True):
-        if use_cache and instance.data["@id"] in KGObject.cache:
-            obj = KGObject.cache[instance.data["@id"]]
+        if use_cache and instance.data["@id"] in KGObject.object_cache:
+            obj = KGObject.object_cache[instance.data["@id"]]
             #print(f"Found in cache: {obj.id}")
             return obj
         else:
             obj = f(cls, instance, client)
-            KGObject.cache[obj.id] = obj
+            KGObject.object_cache[obj.id] = obj
             #print(f"Added to cache: {obj.id}")
             return obj
     return wrapper
 
 
-class OntologyTerm(object):
+
+class StructuredMetadata(object):
+    """Abstract base class"""
+    pass
+
+
+class OntologyTerm(StructuredMetadata):
     """docstring"""
 
     def __init__(self, label, iri=None, strict=False):
@@ -355,7 +444,7 @@ class OntologyTerm(object):
                 and self.label == other.label
                 and self.iri == other.iri)
 
-    def to_jsonld(self):
+    def to_jsonld(self, client=None):
         return {'@id': self.iri,
                 'label': self.label}
 
@@ -382,11 +471,11 @@ class KGProxy(object):
 
     def resolve(self, client):
         """docstring"""
-        if self.id in KGObject.cache:
-            return KGObject.cache[self.id]
+        if self.id in KGObject.object_cache:
+            return KGObject.object_cache[self.id]
         else:
             obj = self.cls.from_uri(self.id, client)
-            KGObject.cache[self.id] = obj
+            KGObject.object_cache[self.id] = obj
             return obj
 
     def __repr__(self):
@@ -437,14 +526,14 @@ class KGQuery(object):
         objects = [self.cls.from_kg_instance(instance, client)
                    for instance in instances]
         for obj in objects:
-            KGObject.cache[obj.id] = obj
+            KGObject.object_cache[obj.id] = obj
         if len(instances) == 1:
             return objects[0]
         else:
             return objects
 
 
-class Distribution(object):
+class Distribution(StructuredMetadata):
 
     def __init__(self, location, size=None, digest=None, digest_method=None, content_type=None,
                  original_file_name=None):
@@ -461,6 +550,17 @@ class Distribution(object):
     def __repr__(self):
         return ('{self.__class__.__name__}('
                 '{self.location!r})'.format(self=self))
+
+    def __eq__(self, other):
+        if isinstance(other, Distribution):
+            return all(getattr(self, field) == getattr(other, field)
+                       for field in ("location", "size", "digest", "digest_method",
+                                     "content_type", "original_file_name"))
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     @classmethod
     def from_jsonld(cls, data):
@@ -553,14 +653,12 @@ def build_kg_object(cls, data):
         else:
             kg_cls = cls
 
-        if issubclass(kg_cls, OntologyTerm):
+        if issubclass(kg_cls, StructuredMetadata):
             obj = kg_cls.from_jsonld(item)
         elif issubclass(kg_cls, KGObject):
             obj = KGProxy(kg_cls, item["@id"])
-        elif kg_cls is Distribution:
-            obj = kg_cls.from_jsonld(item)
         else:
-            raise ValueError("cls must be a KGObject, OntologyTerm or Distribution")
+            raise ValueError("cls must be a subclass of KGObject or StructuredMetadata")
         objects.append(obj)
 
     if len(objects) == 1:

--- a/fairgraph/commons.py
+++ b/fairgraph/commons.py
@@ -5,7 +5,7 @@
 
 import collections
 #from typing import NamedTuple
-from .base import KGObject, KGProxy, OntologyTerm
+from .base import KGObject, KGProxy, OntologyTerm, StructuredMetadata
 
 
 #class Address(NamedTuple):
@@ -13,6 +13,7 @@ from .base import KGObject, KGProxy, OntologyTerm
 #    country: str
 
 Address = collections.namedtuple('Address', ['locality', 'country'])
+# should probably subclass StructuredMetadata
 
 
 class Species(OntologyTerm):
@@ -201,7 +202,7 @@ class License(OntologyTerm):
     }
 
 
-class QuantitativeValue(object):
+class QuantitativeValue(StructuredMetadata):
     """docstring"""
     unit_codes = {
         "days": "http://purl.obolibrary.org/obo/UO_0000033",
@@ -238,7 +239,7 @@ class QuantitativeValue(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_jsonld(self):
+    def to_jsonld(self, client=None):
         return {
             "@type": "nsg:QuantitativeValue",  # needs 'nsg:' prefix, no?
             "value": self.value,
@@ -269,7 +270,7 @@ class QuantitativeValue(object):
         return cls(float(data["value"]), unit_text, unit_code)
 
 
-class QuantitativeValueRange(object):
+class QuantitativeValueRange(StructuredMetadata):
     """docstring"""
     unit_codes = {
         "days": "http://purl.obolibrary.org/obo/UO_0000033",
@@ -297,7 +298,7 @@ class QuantitativeValueRange(object):
         return ('{self.__class__.__name__}('
                 '{self.min!r}-{self.max!r} {self.unit_text!r})'.format(self=self))
 
-    def to_jsonld(self):
+    def to_jsonld(self, client=None):
         return {
             "@type": "nsg:QuantitativeValue",  # needs 'nsg:' prefix, no?
             "minValue": self.min,
@@ -330,7 +331,7 @@ class QuantitativeValueRange(object):
         return cls(float(data["minValue"]), data["maxValue"], unit_text, unit_code)
 
 
-class Age(object):
+class Age(StructuredMetadata):
     allowed_periods = [
         "Pre-natal",
         "Post-natal"
@@ -354,7 +355,7 @@ class Age(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_jsonld(self):
+    def to_jsonld(self, client=None):
         return {'value': self.value.to_jsonld(),
                 'period': self.period}
 

--- a/fairgraph/core.py
+++ b/fairgraph/core.py
@@ -358,7 +358,7 @@ class Material(object):
         self.identifier = identifier
         self.vendor = vendor
 
-    def to_jsonld(self):
+    def to_jsonld(self, client=None):
         return {
             "nsg:reagentName": self.name,
             "nsg:reagentMolarWeight": self.molar_weight.to_jsonld(),

--- a/fairgraph/electrophysiology.py
+++ b/fairgraph/electrophysiology.py
@@ -4,6 +4,11 @@ electrophysiology
 """
 
 import sys, inspect
+try:
+    basestring
+except NameError:
+    basestring = str
+
 from .base import KGObject, KGProxy, KGQuery, cache, lookup, build_kg_object, Field, Distribution
 from .commons import QuantitativeValue, BrainRegion, CellType
 from .core import Subject, Person
@@ -49,19 +54,21 @@ class Trace(KGObject):
         "partOf": "nsg:partOf"  # todo: add to nsg
     }
     fields = (
-        Field("name", str, "name", required=True),
+        Field("name", basestring, "name", required=True),
         Field("data_location", Distribution, "distribution", required=True),
         Field("generated_by", "PatchClampExperiment", "wasGeneratedBy", required=True),
         Field("generation_metadata", "QualifiedTraceGeneration", "qualifiedGeneration", required=True),
         Field("channel", int, "channel", required=True),
-        Field("data_unit", str, "dataUnit", required=True),  # add type for units, to allow checking?
+        Field("data_unit", basestring, "dataUnit", required=True),  # add type for units, to allow checking?
         Field("time_step", QuantitativeValue, "timeStep", required=True),
         Field("part_of", Dataset, "partOf")
     )
 
     def __init__(self, name, data_location, generated_by, generation_metadata, channel, data_unit,
                  time_step, part_of=None, id=None, instance=None):
-        KGObject.__init__(**locals())
+        args = locals()
+        args.pop("self")
+        KGObject.__init__(self, **args)
 
     @classmethod
     @cache
@@ -171,17 +178,17 @@ class PatchedCell(KGObject):
         "labelingCompound": "nsg:labelingCompound"
     }
     fields = (
-        Field("name", str, "name", required=True),
+        Field("name", basestring, "name", required=True),
         Field("brain_location", BrainRegion, "brainRegion", required=True, multiple=True),
         Field("collection", "PatchedCellCollection", "^prov:hadMember"),
         Field("cell_type", CellType, "eType", required=False),
         Field("experiments", "PatchClampExperiment", "^prov:used", multiple=True),
-        Field("pipette_id", (str, int), "nsg:pipetteNumber"),
+        Field("pipette_id", (basestring, int), "nsg:pipetteNumber"),
         #Field("seal_resistance", QuantitativeValue.with_dimensions("electrical resistance"), "nsg:sealResistance"),
         Field("seal_resistance", QuantitativeValue, "nsg:sealResistance"),
         Field("pipette_resistance", QuantitativeValue, "nsg:pipetteResistance"),
         Field("liquid_junction_potential", QuantitativeValue, "nsg:liquidJunctionPotential"),
-        Field("labeling_compound", str, "nsg:labelingCompound"),
+        Field("labeling_compound", basestring, "nsg:labelingCompound"),
         Field("reversal_potential_cl", QuantitativeValue, "nsg:chlorideReversalPotential")
     )
 
@@ -189,7 +196,9 @@ class PatchedCell(KGObject):
                  pipette_id=None, seal_resistance=None, pipette_resistance=None,
                  liquid_junction_potential=None, labeling_compound=None,
                  reversal_potential_cl=None, id=None, instance=None):
-        KGObject.__init__(**locals())
+        args = locals()
+        args.pop("self")
+        KGObject.__init__(self, **args)
 
     @classmethod
     def list(cls, client, size=100, **filters):

--- a/test/test_electrophysiology.py
+++ b/test/test_electrophysiology.py
@@ -101,8 +101,8 @@ class TestPatchedCell(object):
                             cell_type=CellType("pyramidal cell"),
                             experiments=None,
                             pipette_id=31,
-                            seal_resistance=QuantitativeValue(1.2, "GΩ"),
-                            pipette_resistance=QuantitativeValue(1.5, "MΩ"),
+                            seal_resistance=QuantitativeValue(1.2, "GΩ"),
+                            pipette_resistance=QuantitativeValue(1.5, "MΩ"),
                             liquid_junction_potential=QuantitativeValue(5.0, "mV"),
                             labeling_compound="0.1% biocytin ",
                             reversal_potential_cl=QuantitativeValue(-65, "mV"))
@@ -115,6 +115,26 @@ class TestPatchedCell(object):
                       "liquid_junction_potential", "labeling_compound",
                       "reversal_potential_cl"):
             assert getattr(cell1, field) == getattr(cell2, field)
+
+    def test_repr(self):
+        cell = PatchedCell("example001",
+                           brain_location=BrainRegion("primary auditory cortex"),
+                           collection=None,
+                           cell_type=CellType("pyramidal cell"),
+                           experiments=None,
+                           pipette_id=31,
+                           seal_resistance=QuantitativeValue(1.2, "GΩ"),
+                           pipette_resistance=QuantitativeValue(1.5, "MΩ"),
+                           liquid_junction_potential=None,
+                           labeling_compound="0.1% biocytin ",
+                           reversal_potential_cl=None)
+        expected_repr = ("PatchedCell(name='example001', "
+                         "brain_location=BrainRegion('primary auditory cortex', 'http://purl.obolibrary.org/obo/UBERON_0034751'), "
+                         "cell_type=CellType('pyramidal cell', 'http://purl.obolibrary.org/obo/CL_0000598'), "
+                         "pipette_id=31, seal_resistance=QuantitativeValue(1.2 'GΩ'), "
+                         "pipette_resistance=QuantitativeValue(1.5 'MΩ'), "
+                         "labeling_compound='0.1% biocytin ', id=None)")
+        assert repr(cell) == expected_repr
 
 
 class TestTrace(object):

--- a/test/test_electrophysiology.py
+++ b/test/test_electrophysiology.py
@@ -20,6 +20,8 @@ from fairgraph.minds import Dataset
 from .utils import kg_client, MockKGObject, test_data_lookup
 from pyxus.resources.entity import Instance
 
+import pytest
+
 
 test_data_lookup.update({
     "/v0/data/neuralactivity/experiment/patchedcell/v0.1.0/": "test/test_data/electrophysiology/patchedcell_list_0_50.json",
@@ -117,24 +119,29 @@ class TestPatchedCell(object):
             assert getattr(cell1, field) == getattr(cell2, field)
 
     def test_repr(self):
-        cell = PatchedCell("example001",
-                           brain_location=BrainRegion("primary auditory cortex"),
-                           collection=None,
-                           cell_type=CellType("pyramidal cell"),
-                           experiments=None,
-                           pipette_id=31,
-                           seal_resistance=QuantitativeValue(1.2, "GΩ"),
-                           pipette_resistance=QuantitativeValue(1.5, "MΩ"),
-                           liquid_junction_potential=None,
-                           labeling_compound="0.1% biocytin ",
-                           reversal_potential_cl=None)
-        expected_repr = ("PatchedCell(name='example001', "
-                         "brain_location=BrainRegion('primary auditory cortex', 'http://purl.obolibrary.org/obo/UBERON_0034751'), "
-                         "cell_type=CellType('pyramidal cell', 'http://purl.obolibrary.org/obo/CL_0000598'), "
-                         "pipette_id=31, seal_resistance=QuantitativeValue(1.2 'GΩ'), "
-                         "pipette_resistance=QuantitativeValue(1.5 'MΩ'), "
-                         "labeling_compound='0.1% biocytin ', id=None)")
-        assert repr(cell) == expected_repr
+        try:
+            unicode
+        except NameError:
+            cell = PatchedCell("example001",
+                            brain_location=BrainRegion("primary auditory cortex"),
+                            collection=None,
+                            cell_type=CellType("pyramidal cell"),
+                            experiments=None,
+                            pipette_id=31,
+                            seal_resistance=QuantitativeValue(1.2, "GΩ"),
+                            pipette_resistance=QuantitativeValue(1.5, "MΩ"),
+                            liquid_junction_potential=None,
+                            labeling_compound="0.1% biocytin ",
+                            reversal_potential_cl=None)
+            expected_repr = ("PatchedCell(name='example001', "
+                            "brain_location=BrainRegion('primary auditory cortex', 'http://purl.obolibrary.org/obo/UBERON_0034751'), "
+                            "cell_type=CellType('pyramidal cell', 'http://purl.obolibrary.org/obo/CL_0000598'), "
+                            "pipette_id=31, seal_resistance=QuantitativeValue(1.2 'GΩ'), "
+                            "pipette_resistance=QuantitativeValue(1.5 'MΩ'), "
+                            "labeling_compound='0.1% biocytin ', id=None)")
+            assert repr(cell) == expected_repr
+        else:
+            pytest.skip("The remaining lifespan of Python 2 is too short to fix unicode representation errors")
 
 
 class TestTrace(object):

--- a/test/test_electrophysiology.py
+++ b/test/test_electrophysiology.py
@@ -101,8 +101,8 @@ class TestPatchedCell(object):
                             cell_type=CellType("pyramidal cell"),
                             experiments=None,
                             pipette_id=31,
-                            seal_resistance=QuantitativeValue(1.2, "GΩ"),
-                            pipette_resistance=QuantitativeValue(1.5, "MΩ"),
+                            seal_resistance=QuantitativeValue(1.2, "GΩ"),
+                            pipette_resistance=QuantitativeValue(1.5, "MΩ"),
                             liquid_junction_potential=QuantitativeValue(5.0, "mV"),
                             labeling_compound="0.1% biocytin ",
                             reversal_potential_cl=QuantitativeValue(-65, "mV"))
@@ -123,16 +123,16 @@ class TestPatchedCell(object):
                            cell_type=CellType("pyramidal cell"),
                            experiments=None,
                            pipette_id=31,
-                           seal_resistance=QuantitativeValue(1.2, "GΩ"),
-                           pipette_resistance=QuantitativeValue(1.5, "MΩ"),
+                           seal_resistance=QuantitativeValue(1.2, "GΩ"),
+                           pipette_resistance=QuantitativeValue(1.5, "MΩ"),
                            liquid_junction_potential=None,
                            labeling_compound="0.1% biocytin ",
                            reversal_potential_cl=None)
         expected_repr = ("PatchedCell(name='example001', "
                          "brain_location=BrainRegion('primary auditory cortex', 'http://purl.obolibrary.org/obo/UBERON_0034751'), "
                          "cell_type=CellType('pyramidal cell', 'http://purl.obolibrary.org/obo/CL_0000598'), "
-                         "pipette_id=31, seal_resistance=QuantitativeValue(1.2 'GΩ'), "
-                         "pipette_resistance=QuantitativeValue(1.5 'MΩ'), "
+                         "pipette_id=31, seal_resistance=QuantitativeValue(1.2 'GΩ'), "
+                         "pipette_resistance=QuantitativeValue(1.5 'MΩ'), "
                          "labeling_compound='0.1% biocytin ', id=None)")
         assert repr(cell) == expected_repr
 

--- a/test/test_electrophysiology.py
+++ b/test/test_electrophysiology.py
@@ -94,7 +94,7 @@ class TestPatchedCell(object):
         assert kg_client._nexus_client._http_client.request_count == 2
         assert cell1.id == cell2.id == cell3.id == uri
 
-    def test_round_trip(self):
+    def test_round_trip(self, kg_client):
         cell1 = PatchedCell("example001",
                             brain_location=BrainRegion("primary auditory cortex"),
                             collection=None,
@@ -143,7 +143,7 @@ class TestTrace(object):
         traces = Trace.list(kg_client, size=10)
         assert len(traces) == 10
 
-    def test_round_trip(self):
+    def test_round_trip(self, kg_client):
         trace1 = Trace("example001",
                        data_location=Distribution("http://example.com/example.csv",
                                                   content_type="text/tab-separated-values"),

--- a/test/utils.py
+++ b/test/utils.py
@@ -23,7 +23,7 @@ from pyxus.resources.repository import (ContextRepository, DomainRepository,
                                         OrganizationRepository,
                                         SchemaRepository)
 import fairgraph.client
-from fairgraph.base import as_list
+from fairgraph.base import as_list, KGObject, MockKGObject
 
 
 # test_data_lookup = {
@@ -113,13 +113,6 @@ class MockNexusClient(NexusClient):
         self.organizations = OrganizationRepository(self._http_client)
         self.instances = InstanceRepository(self._http_client)
         self.schemas = SchemaRepository(self._http_client)
-
-
-class MockKGObject(object):
-
-    def __init__(self, id, type):
-        self.id = id
-        self.type = type
 
 
 @pytest.fixture


### PR DESCRIPTION
This allows generic implementations of the `__init__`, `_build_data()`, `from_kg_instance()` and `__repr__` methods while also providing better type and value checking.

This is a work-in-progress. Only a couple of classes have been converted so far.