### PR TITLE
Separate forward and reverse properties into different attributes

### DIFF
--- a/builder/fairgraph_module_template.py.txt
+++ b/builder/fairgraph_module_template.py.txt
@@ -32,6 +32,8 @@ class {{ class_name }}({{ base_class }}):
             {%- if prop.required %}required={{prop.required}},{% endif -%}
             doc="{{prop.doc}}"),
         {% endfor %}
+    ]
+    reverse_properties = [
         {% for prop in reverse_properties -%}
         Property(
             "{{prop.name}}", {{prop.type_str}},

--- a/fairgraph/openminds/chemicals/amount_of_chemical.py
+++ b/fairgraph/openminds/chemicals/amount_of_chemical.py
@@ -35,7 +35,7 @@ class AmountOfChemical(EmbeddedMetadata):
             doc="no description available",
         ),
     ]
-    existence_query_properties = ("chemical_product", "amount")
+    reverse_properties = []
 
     def __init__(self, amount=None, chemical_product=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, amount=amount, chemical_product=chemical_product)

--- a/fairgraph/openminds/chemicals/chemical_mixture.py
+++ b/fairgraph/openminds/chemicals/chemical_mixture.py
@@ -56,6 +56,8 @@ class ChemicalMixture(KGObject):
             required=True,
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "composes",
             ["openminds.ephys.Electrode", "openminds.ephys.ElectrodeArray", "openminds.ephys.Pipette"],

--- a/fairgraph/openminds/chemicals/chemical_substance.py
+++ b/fairgraph/openminds/chemicals/chemical_substance.py
@@ -49,6 +49,8 @@ class ChemicalSubstance(KGObject):
             "vocab:purity",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "composes",
             ["openminds.ephys.Electrode", "openminds.ephys.ElectrodeArray", "openminds.ephys.Pipette"],

--- a/fairgraph/openminds/chemicals/product_source.py
+++ b/fairgraph/openminds/chemicals/product_source.py
@@ -44,6 +44,8 @@ class ProductSource(KGObject):
             "vocab:purity",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_source_of",
             ["openminds.chemicals.ChemicalMixture", "openminds.chemicals.ChemicalSubstance"],

--- a/fairgraph/openminds/computation/data_analysis.py
+++ b/fairgraph/openminds/computation/data_analysis.py
@@ -167,6 +167,8 @@ class DataAnalysis(KGObject):
             "vocab:wasInformedBy",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "informed",
             [

--- a/fairgraph/openminds/computation/data_copy.py
+++ b/fairgraph/openminds/computation/data_copy.py
@@ -163,6 +163,8 @@ class DataCopy(KGObject):
             "vocab:wasInformedBy",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "informed",
             [

--- a/fairgraph/openminds/computation/environment.py
+++ b/fairgraph/openminds/computation/environment.py
@@ -53,6 +53,8 @@ class Environment(KGObject):
             multiple=True,
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "used_for",
             [

--- a/fairgraph/openminds/computation/generic_computation.py
+++ b/fairgraph/openminds/computation/generic_computation.py
@@ -165,6 +165,8 @@ class GenericComputation(KGObject):
             "vocab:wasInformedBy",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "informed",
             [

--- a/fairgraph/openminds/computation/hardware_system.py
+++ b/fairgraph/openminds/computation/hardware_system.py
@@ -42,6 +42,8 @@ class HardwareSystem(KGObject):
             "vocab:versionIdentifier",
             doc="Term or code used to identify the version of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "used_by",
             "openminds.computation.Environment",

--- a/fairgraph/openminds/computation/launch_configuration.py
+++ b/fairgraph/openminds/computation/launch_configuration.py
@@ -43,6 +43,8 @@ class LaunchConfiguration(KGObject):
             "vocab:name",
             doc="Word or phrase that constitutes the distinctive designation of the launch configuration.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_launch_configuration_of",
             [

--- a/fairgraph/openminds/computation/local_file.py
+++ b/fairgraph/openminds/computation/local_file.py
@@ -64,6 +64,8 @@ class LocalFile(KGObject):
             "vocab:storageSize",
             doc="Quantitative value defining how much disk space is used by an object on a computer system.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_output_of",
             [

--- a/fairgraph/openminds/computation/model_validation.py
+++ b/fairgraph/openminds/computation/model_validation.py
@@ -163,6 +163,8 @@ class ModelValidation(KGObject):
             "vocab:wasInformedBy",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "informed",
             [

--- a/fairgraph/openminds/computation/optimization.py
+++ b/fairgraph/openminds/computation/optimization.py
@@ -166,6 +166,8 @@ class Optimization(KGObject):
             "vocab:wasInformedBy",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "informed",
             [

--- a/fairgraph/openminds/computation/simulation.py
+++ b/fairgraph/openminds/computation/simulation.py
@@ -166,6 +166,8 @@ class Simulation(KGObject):
             "vocab:wasInformedBy",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "informed",
             [

--- a/fairgraph/openminds/computation/software_agent.py
+++ b/fairgraph/openminds/computation/software_agent.py
@@ -40,6 +40,8 @@ class SoftwareAgent(KGObject):
             required=True,
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "activities",
             [

--- a/fairgraph/openminds/computation/validation_test.py
+++ b/fairgraph/openminds/computation/validation_test.py
@@ -133,6 +133,8 @@ class ValidationTest(KGObject):
             multiple=True,
             doc="Structure or function that was targeted within a study.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/computation/validation_test_version.py
+++ b/fairgraph/openminds/computation/validation_test_version.py
@@ -88,7 +88,7 @@ class ValidationTestVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -166,6 +166,7 @@ class ValidationTestVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -286,6 +287,8 @@ class ValidationTestVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/computation/visualization.py
+++ b/fairgraph/openminds/computation/visualization.py
@@ -165,6 +165,8 @@ class Visualization(KGObject):
             "vocab:wasInformedBy",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "informed",
             [

--- a/fairgraph/openminds/computation/workflow_execution.py
+++ b/fairgraph/openminds/computation/workflow_execution.py
@@ -54,6 +54,7 @@ class WorkflowExecution(KGObject):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("stages",)
 
     def __init__(

--- a/fairgraph/openminds/computation/workflow_recipe.py
+++ b/fairgraph/openminds/computation/workflow_recipe.py
@@ -83,6 +83,8 @@ class WorkflowRecipe(KGObject):
             required=True,
             doc="Shortened or fully abbreviated name of the workflow recipe.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/computation/workflow_recipe_version.py
+++ b/fairgraph/openminds/computation/workflow_recipe_version.py
@@ -75,7 +75,7 @@ class WorkflowRecipeVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -165,6 +165,7 @@ class WorkflowRecipeVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -278,6 +279,8 @@ class WorkflowRecipeVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/controlled_terms/__init__.py
+++ b/fairgraph/openminds/controlled_terms/__init__.py
@@ -49,6 +49,7 @@ from .meta_data_model_type import MetaDataModelType
 from .model_abstraction_level import ModelAbstractionLevel
 from .model_scope import ModelScope
 from .molecular_entity import MolecularEntity
+from .mri_pulse_sequence import MRIPulseSequence
 from .olfactory_stimulus_type import OlfactoryStimulusType
 from .operating_device import OperatingDevice
 from .operating_system import OperatingSystem

--- a/fairgraph/openminds/controlled_terms/action_status_type.py
+++ b/fairgraph/openminds/controlled_terms/action_status_type.py
@@ -70,6 +70,8 @@ class ActionStatusType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/age_category.py
+++ b/fairgraph/openminds/controlled_terms/age_category.py
@@ -70,6 +70,8 @@ class AgeCategory(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/analysis_technique.py
+++ b/fairgraph/openminds/controlled_terms/analysis_technique.py
@@ -70,6 +70,8 @@ class AnalysisTechnique(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/anatomical_axes_orientation.py
+++ b/fairgraph/openminds/controlled_terms/anatomical_axes_orientation.py
@@ -70,6 +70,8 @@ class AnatomicalAxesOrientation(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/anatomical_identification_type.py
+++ b/fairgraph/openminds/controlled_terms/anatomical_identification_type.py
@@ -70,6 +70,8 @@ class AnatomicalIdentificationType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/anatomical_plane.py
+++ b/fairgraph/openminds/controlled_terms/anatomical_plane.py
@@ -70,6 +70,8 @@ class AnatomicalPlane(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/annotation_criteria_type.py
+++ b/fairgraph/openminds/controlled_terms/annotation_criteria_type.py
@@ -70,6 +70,8 @@ class AnnotationCriteriaType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/annotation_type.py
+++ b/fairgraph/openminds/controlled_terms/annotation_type.py
@@ -70,6 +70,8 @@ class AnnotationType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/atlas_type.py
+++ b/fairgraph/openminds/controlled_terms/atlas_type.py
@@ -70,6 +70,8 @@ class AtlasType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/auditory_stimulus_type.py
+++ b/fairgraph/openminds/controlled_terms/auditory_stimulus_type.py
@@ -70,6 +70,8 @@ class AuditoryStimulusType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/biological_order.py
+++ b/fairgraph/openminds/controlled_terms/biological_order.py
@@ -70,6 +70,8 @@ class BiologicalOrder(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/biological_process.py
+++ b/fairgraph/openminds/controlled_terms/biological_process.py
@@ -70,6 +70,8 @@ class BiologicalProcess(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/biological_sex.py
+++ b/fairgraph/openminds/controlled_terms/biological_sex.py
@@ -70,6 +70,8 @@ class BiologicalSex(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/breeding_type.py
+++ b/fairgraph/openminds/controlled_terms/breeding_type.py
@@ -70,6 +70,8 @@ class BreedingType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/cell_culture_type.py
+++ b/fairgraph/openminds/controlled_terms/cell_culture_type.py
@@ -70,6 +70,8 @@ class CellCultureType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/cell_type.py
+++ b/fairgraph/openminds/controlled_terms/cell_type.py
@@ -70,6 +70,8 @@ class CellType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/chemical_mixture_type.py
+++ b/fairgraph/openminds/controlled_terms/chemical_mixture_type.py
@@ -70,6 +70,8 @@ class ChemicalMixtureType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/colormap.py
+++ b/fairgraph/openminds/controlled_terms/colormap.py
@@ -70,6 +70,8 @@ class Colormap(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/contribution_type.py
+++ b/fairgraph/openminds/controlled_terms/contribution_type.py
@@ -70,6 +70,8 @@ class ContributionType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/cranial_window_construction_type.py
+++ b/fairgraph/openminds/controlled_terms/cranial_window_construction_type.py
@@ -70,6 +70,8 @@ class CranialWindowConstructionType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/cranial_window_reinforcement_type.py
+++ b/fairgraph/openminds/controlled_terms/cranial_window_reinforcement_type.py
@@ -70,6 +70,8 @@ class CranialWindowReinforcementType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/criteria_quality_type.py
+++ b/fairgraph/openminds/controlled_terms/criteria_quality_type.py
@@ -70,6 +70,8 @@ class CriteriaQualityType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/data_type.py
+++ b/fairgraph/openminds/controlled_terms/data_type.py
@@ -70,6 +70,8 @@ class DataType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/difference_measure.py
+++ b/fairgraph/openminds/controlled_terms/difference_measure.py
@@ -70,6 +70,8 @@ class DifferenceMeasure(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/disease.py
+++ b/fairgraph/openminds/controlled_terms/disease.py
@@ -70,6 +70,8 @@ class Disease(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/disease_model.py
+++ b/fairgraph/openminds/controlled_terms/disease_model.py
@@ -70,6 +70,8 @@ class DiseaseModel(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/educational_level.py
+++ b/fairgraph/openminds/controlled_terms/educational_level.py
@@ -70,6 +70,8 @@ class EducationalLevel(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/electrical_stimulus_type.py
+++ b/fairgraph/openminds/controlled_terms/electrical_stimulus_type.py
@@ -70,6 +70,8 @@ class ElectricalStimulusType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/ethics_assessment.py
+++ b/fairgraph/openminds/controlled_terms/ethics_assessment.py
@@ -70,6 +70,8 @@ class EthicsAssessment(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/experimental_approach.py
+++ b/fairgraph/openminds/controlled_terms/experimental_approach.py
@@ -70,6 +70,8 @@ class ExperimentalApproach(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/file_bundle_grouping.py
+++ b/fairgraph/openminds/controlled_terms/file_bundle_grouping.py
@@ -70,6 +70,8 @@ class FileBundleGrouping(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/file_repository_type.py
+++ b/fairgraph/openminds/controlled_terms/file_repository_type.py
@@ -70,6 +70,8 @@ class FileRepositoryType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/file_usage_role.py
+++ b/fairgraph/openminds/controlled_terms/file_usage_role.py
@@ -70,6 +70,8 @@ class FileUsageRole(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/genetic_strain_type.py
+++ b/fairgraph/openminds/controlled_terms/genetic_strain_type.py
@@ -70,6 +70,8 @@ class GeneticStrainType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/gustatory_stimulus_type.py
+++ b/fairgraph/openminds/controlled_terms/gustatory_stimulus_type.py
@@ -70,6 +70,8 @@ class GustatoryStimulusType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/handedness.py
+++ b/fairgraph/openminds/controlled_terms/handedness.py
@@ -70,6 +70,8 @@ class Handedness(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/language.py
+++ b/fairgraph/openminds/controlled_terms/language.py
@@ -70,6 +70,8 @@ class Language(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/laterality.py
+++ b/fairgraph/openminds/controlled_terms/laterality.py
@@ -70,6 +70,8 @@ class Laterality(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/learning_resource_type.py
+++ b/fairgraph/openminds/controlled_terms/learning_resource_type.py
@@ -70,6 +70,8 @@ class LearningResourceType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/measured_quantity.py
+++ b/fairgraph/openminds/controlled_terms/measured_quantity.py
@@ -70,6 +70,8 @@ class MeasuredQuantity(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/measured_signal_type.py
+++ b/fairgraph/openminds/controlled_terms/measured_signal_type.py
@@ -70,6 +70,8 @@ class MeasuredSignalType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/meta_data_model_type.py
+++ b/fairgraph/openminds/controlled_terms/meta_data_model_type.py
@@ -70,6 +70,8 @@ class MetaDataModelType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/model_abstraction_level.py
+++ b/fairgraph/openminds/controlled_terms/model_abstraction_level.py
@@ -70,6 +70,8 @@ class ModelAbstractionLevel(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/model_scope.py
+++ b/fairgraph/openminds/controlled_terms/model_scope.py
@@ -70,6 +70,8 @@ class ModelScope(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/molecular_entity.py
+++ b/fairgraph/openminds/controlled_terms/molecular_entity.py
@@ -70,6 +70,8 @@ class MolecularEntity(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "composes",
             [

--- a/fairgraph/openminds/controlled_terms/mri_pulse_sequence.py
+++ b/fairgraph/openminds/controlled_terms/mri_pulse_sequence.py
@@ -11,13 +11,13 @@ from fairgraph.properties import Property
 from fairgraph.base import IRI
 
 
-class DeviceType(KGObject):
+class MRIPulseSequence(KGObject):
     """
     <description not available>
     """
 
     default_space = "controlled"
-    type_ = ["https://openminds.ebrains.eu/controlledTerms/DeviceType"]
+    type_ = ["https://openminds.ebrains.eu/controlledTerms/MRIPulseSequence"]
     context = {
         "schema": "http://schema.org/",
         "kg": "https://kg.ebrains.eu/api/instances/",
@@ -36,7 +36,7 @@ class DeviceType(KGObject):
             "description",
             str,
             "vocab:description",
-            doc="Longer statement or account giving the characteristics of the device type.",
+            doc="Longer statement or account giving the characteristics of the m r i pulse sequence.",
         ),
         Property(
             "interlex_identifier",
@@ -55,7 +55,7 @@ class DeviceType(KGObject):
             str,
             "vocab:name",
             required=True,
-            doc="Word or phrase that constitutes the distinctive designation of the device type.",
+            doc="Word or phrase that constitutes the distinctive designation of the m r i pulse sequence.",
         ),
         Property(
             "preferred_ontology_identifier",
@@ -77,7 +77,6 @@ class DeviceType(KGObject):
             [
                 "openminds.computation.ValidationTestVersion",
                 "openminds.computation.WorkflowRecipeVersion",
-                "openminds.core.DatasetVersion",
                 "openminds.core.MetaDataModelVersion",
                 "openminds.core.ModelVersion",
                 "openminds.core.SoftwareVersion",
@@ -96,17 +95,20 @@ class DeviceType(KGObject):
             doc="reverse of 'keyword'",
         ),
         Property(
-            "is_type_of",
-            [
-                "openminds.ephys.Electrode",
-                "openminds.ephys.ElectrodeArray",
-                "openminds.ephys.Pipette",
-                "openminds.specimen_prep.SlicingDevice",
-            ],
-            "^vocab:deviceType",
-            reverse="device_types",
+            "is_used_to_group",
+            "openminds.core.FileBundle",
+            "^vocab:groupedBy",
+            reverse="grouped_by",
             multiple=True,
-            doc="reverse of 'deviceType'",
+            doc="reverse of 'groupedBy'",
+        ),
+        Property(
+            "used_in",
+            ["openminds.core.DatasetVersion", "openminds.core.Protocol"],
+            "^vocab:technique",
+            reverse="techniques",
+            multiple=True,
+            doc="reverse of 'technique'",
         ),
     ]
     existence_query_properties = ("name",)
@@ -118,10 +120,11 @@ class DeviceType(KGObject):
         describes=None,
         description=None,
         interlex_identifier=None,
-        is_type_of=None,
+        is_used_to_group=None,
         knowledge_space_link=None,
         preferred_ontology_identifier=None,
         synonyms=None,
+        used_in=None,
         id=None,
         data=None,
         space=None,
@@ -137,8 +140,9 @@ class DeviceType(KGObject):
             describes=describes,
             description=description,
             interlex_identifier=interlex_identifier,
-            is_type_of=is_type_of,
+            is_used_to_group=is_used_to_group,
             knowledge_space_link=knowledge_space_link,
             preferred_ontology_identifier=preferred_ontology_identifier,
             synonyms=synonyms,
+            used_in=used_in,
         )

--- a/fairgraph/openminds/controlled_terms/olfactory_stimulus_type.py
+++ b/fairgraph/openminds/controlled_terms/olfactory_stimulus_type.py
@@ -70,6 +70,8 @@ class OlfactoryStimulusType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/operating_device.py
+++ b/fairgraph/openminds/controlled_terms/operating_device.py
@@ -70,6 +70,8 @@ class OperatingDevice(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/operating_system.py
+++ b/fairgraph/openminds/controlled_terms/operating_system.py
@@ -70,6 +70,8 @@ class OperatingSystem(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/optical_stimulus_type.py
+++ b/fairgraph/openminds/controlled_terms/optical_stimulus_type.py
@@ -70,6 +70,8 @@ class OpticalStimulusType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/organ.py
+++ b/fairgraph/openminds/controlled_terms/organ.py
@@ -70,6 +70,8 @@ class Organ(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "defines",
             ["openminds.sands.CustomAnatomicalEntity", "openminds.sands.ParcellationEntity"],

--- a/fairgraph/openminds/controlled_terms/organism_substance.py
+++ b/fairgraph/openminds/controlled_terms/organism_substance.py
@@ -70,6 +70,8 @@ class OrganismSubstance(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/organism_system.py
+++ b/fairgraph/openminds/controlled_terms/organism_system.py
@@ -70,6 +70,8 @@ class OrganismSystem(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/patch_clamp_variation.py
+++ b/fairgraph/openminds/controlled_terms/patch_clamp_variation.py
@@ -70,6 +70,8 @@ class PatchClampVariation(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/preparation_type.py
+++ b/fairgraph/openminds/controlled_terms/preparation_type.py
@@ -70,6 +70,8 @@ class PreparationType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/product_accessibility.py
+++ b/fairgraph/openminds/controlled_terms/product_accessibility.py
@@ -70,6 +70,8 @@ class ProductAccessibility(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/programming_language.py
+++ b/fairgraph/openminds/controlled_terms/programming_language.py
@@ -70,6 +70,8 @@ class ProgrammingLanguage(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/qualitative_overlap.py
+++ b/fairgraph/openminds/controlled_terms/qualitative_overlap.py
@@ -70,6 +70,8 @@ class QualitativeOverlap(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/semantic_data_type.py
+++ b/fairgraph/openminds/controlled_terms/semantic_data_type.py
@@ -70,6 +70,8 @@ class SemanticDataType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/service.py
+++ b/fairgraph/openminds/controlled_terms/service.py
@@ -70,6 +70,8 @@ class Service(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/setup_type.py
+++ b/fairgraph/openminds/controlled_terms/setup_type.py
@@ -70,6 +70,8 @@ class SetupType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/software_application_category.py
+++ b/fairgraph/openminds/controlled_terms/software_application_category.py
@@ -70,6 +70,8 @@ class SoftwareApplicationCategory(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/software_feature.py
+++ b/fairgraph/openminds/controlled_terms/software_feature.py
@@ -70,6 +70,8 @@ class SoftwareFeature(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/species.py
+++ b/fairgraph/openminds/controlled_terms/species.py
@@ -70,6 +70,8 @@ class Species(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "common_coordinate_space",
             ["openminds.sands.BrainAtlas", "openminds.sands.CommonCoordinateSpace"],

--- a/fairgraph/openminds/controlled_terms/stimulation_approach.py
+++ b/fairgraph/openminds/controlled_terms/stimulation_approach.py
@@ -70,6 +70,8 @@ class StimulationApproach(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/stimulation_technique.py
+++ b/fairgraph/openminds/controlled_terms/stimulation_technique.py
@@ -70,6 +70,8 @@ class StimulationTechnique(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/subcellular_entity.py
+++ b/fairgraph/openminds/controlled_terms/subcellular_entity.py
@@ -70,6 +70,8 @@ class SubcellularEntity(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/subject_attribute.py
+++ b/fairgraph/openminds/controlled_terms/subject_attribute.py
@@ -70,6 +70,8 @@ class SubjectAttribute(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/tactile_stimulus_type.py
+++ b/fairgraph/openminds/controlled_terms/tactile_stimulus_type.py
@@ -70,6 +70,8 @@ class TactileStimulusType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/technique.py
+++ b/fairgraph/openminds/controlled_terms/technique.py
@@ -70,6 +70,8 @@ class Technique(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/term_suggestion.py
+++ b/fairgraph/openminds/controlled_terms/term_suggestion.py
@@ -82,6 +82,8 @@ class TermSuggestion(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/terminology.py
+++ b/fairgraph/openminds/controlled_terms/terminology.py
@@ -70,6 +70,8 @@ class Terminology(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/tissue_sample_attribute.py
+++ b/fairgraph/openminds/controlled_terms/tissue_sample_attribute.py
@@ -70,6 +70,8 @@ class TissueSampleAttribute(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/tissue_sample_type.py
+++ b/fairgraph/openminds/controlled_terms/tissue_sample_type.py
@@ -70,6 +70,8 @@ class TissueSampleType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/type_of_uncertainty.py
+++ b/fairgraph/openminds/controlled_terms/type_of_uncertainty.py
@@ -70,6 +70,8 @@ class TypeOfUncertainty(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/uberon_parcellation.py
+++ b/fairgraph/openminds/controlled_terms/uberon_parcellation.py
@@ -70,6 +70,8 @@ class UBERONParcellation(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "defines",
             ["openminds.sands.CustomAnatomicalEntity", "openminds.sands.ParcellationEntity"],

--- a/fairgraph/openminds/controlled_terms/unit_of_measurement.py
+++ b/fairgraph/openminds/controlled_terms/unit_of_measurement.py
@@ -70,6 +70,8 @@ class UnitOfMeasurement(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/controlled_terms/visual_stimulus_type.py
+++ b/fairgraph/openminds/controlled_terms/visual_stimulus_type.py
@@ -70,6 +70,8 @@ class VisualStimulusType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/core/actors/account_information.py
+++ b/fairgraph/openminds/core/actors/account_information.py
@@ -27,6 +27,8 @@ class AccountInformation(KGObject):
             "service", "openminds.core.WebService", "vocab:service", required=True, doc="no description available"
         ),
         Property("user_name", str, "vocab:userName", required=True, doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "belongs_to",
             "openminds.core.Person",

--- a/fairgraph/openminds/core/actors/affiliation.py
+++ b/fairgraph/openminds/core/actors/affiliation.py
@@ -45,6 +45,7 @@ class Affiliation(EmbeddedMetadata):
             doc="Date in the Gregorian calendar at which something begins in time",
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, end_date=None, member_of=None, start_date=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, end_date=end_date, member_of=member_of, start_date=start_date)

--- a/fairgraph/openminds/core/actors/consortium.py
+++ b/fairgraph/openminds/core/actors/consortium.py
@@ -37,6 +37,8 @@ class Consortium(KGObject):
         ),
         Property("homepage", IRI, "vocab:homepage", doc="Main website of the consortium."),
         Property("short_name", str, "vocab:shortName", doc="Shortened or fully abbreviated name of the consortium."),
+    ]
+    reverse_properties = [
         Property(
             "coordinated_projects",
             "openminds.core.Project",

--- a/fairgraph/openminds/core/actors/contact_information.py
+++ b/fairgraph/openminds/core/actors/contact_information.py
@@ -30,6 +30,8 @@ class ContactInformation(KGObject):
             required=True,
             doc="Address to which or from which an electronic mail can be sent.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_contact_information_of",
             ["openminds.core.Consortium", "openminds.core.Person"],

--- a/fairgraph/openminds/core/actors/contribution.py
+++ b/fairgraph/openminds/core/actors/contribution.py
@@ -38,6 +38,7 @@ class Contribution(EmbeddedMetadata):
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, contributor=None, types=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, contributor=contributor, types=types)

--- a/fairgraph/openminds/core/actors/organization.py
+++ b/fairgraph/openminds/core/actors/organization.py
@@ -52,6 +52,8 @@ class Organization(KGObject):
         ),
         Property("homepage", IRI, "vocab:homepage", doc="Main website of the organization."),
         Property("short_name", str, "vocab:shortName", doc="Shortened or fully abbreviated name of the organization."),
+    ]
+    reverse_properties = [
         Property(
             "coordinated_projects",
             "openminds.core.Project",

--- a/fairgraph/openminds/core/actors/person.py
+++ b/fairgraph/openminds/core/actors/person.py
@@ -59,6 +59,8 @@ class Person(KGObject):
             required=True,
             doc="Name given to a person, including all potential middle names, but excluding the family name.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "activities",
             [

--- a/fairgraph/openminds/core/data/content_type.py
+++ b/fairgraph/openminds/core/data/content_type.py
@@ -73,6 +73,8 @@ class ContentType(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_defined_by",
             "openminds.core.ContentTypePattern",

--- a/fairgraph/openminds/core/data/content_type_pattern.py
+++ b/fairgraph/openminds/core/data/content_type_pattern.py
@@ -32,6 +32,8 @@ class ContentTypePattern(KGObject):
         ),
         Property("lookup_label", str, "vocab:lookupLabel", doc="no description available"),
         Property("regex", str, "vocab:regex", required=True, doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "identifies_content_of",
             "openminds.core.FileRepository",

--- a/fairgraph/openminds/core/data/copyright.py
+++ b/fairgraph/openminds/core/data/copyright.py
@@ -39,6 +39,7 @@ class Copyright(EmbeddedMetadata):
             doc="Cycle in the Gregorian calendar specified by a number and comprised of 365 or 366 days divided into 12 months beginning with January and ending with December.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, holders=None, years=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, holders=holders, years=years)

--- a/fairgraph/openminds/core/data/file.py
+++ b/fairgraph/openminds/core/data/file.py
@@ -94,6 +94,8 @@ class File(KGObject):
             "vocab:storageSize",
             doc="Quantitative value defining how much disk space is used by an object on a computer system.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/core/data/file_archive.py
+++ b/fairgraph/openminds/core/data/file_archive.py
@@ -43,6 +43,8 @@ class FileArchive(KGObject):
         Property(
             "source_data", "openminds.core.File", "vocab:sourceData", multiple=True, doc="no description available"
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_location_of",
             "openminds.core.ServiceLink",

--- a/fairgraph/openminds/core/data/file_bundle.py
+++ b/fairgraph/openminds/core/data/file_bundle.py
@@ -47,6 +47,7 @@ class FileBundle(KGObject):
                 "openminds.controlled_terms.GeneticStrainType",
                 "openminds.controlled_terms.GustatoryStimulusType",
                 "openminds.controlled_terms.Handedness",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MolecularEntity",
                 "openminds.controlled_terms.OlfactoryStimulusType",
                 "openminds.controlled_terms.OpticalStimulusType",
@@ -118,6 +119,8 @@ class FileBundle(KGObject):
             "vocab:storageSize",
             doc="Quantitative value defining how much disk space is used by an object on a computer system.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             [

--- a/fairgraph/openminds/core/data/file_path_pattern.py
+++ b/fairgraph/openminds/core/data/file_path_pattern.py
@@ -32,6 +32,7 @@ class FilePathPattern(EmbeddedMetadata):
         ),
         Property("regex", str, "vocab:regex", required=True, doc="no description available"),
     ]
+    reverse_properties = []
 
     def __init__(self, grouping_types=None, regex=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, grouping_types=grouping_types, regex=regex)

--- a/fairgraph/openminds/core/data/file_repository.py
+++ b/fairgraph/openminds/core/data/file_repository.py
@@ -84,6 +84,8 @@ class FileRepository(KGObject):
             "vocab:type",
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "contains_content_of",
             [

--- a/fairgraph/openminds/core/data/file_repository_structure.py
+++ b/fairgraph/openminds/core/data/file_repository_structure.py
@@ -32,6 +32,8 @@ class FileRepositoryStructure(KGObject):
             doc="no description available",
         ),
         Property("lookup_label", str, "vocab:lookupLabel", doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "structures",
             "openminds.core.FileRepository",

--- a/fairgraph/openminds/core/data/hash.py
+++ b/fairgraph/openminds/core/data/hash.py
@@ -33,6 +33,7 @@ class Hash(EmbeddedMetadata):
             "digest", str, "vocab:digest", required=True, doc="Summation or condensation of a body of information."
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, algorithm=None, digest=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, algorithm=algorithm, digest=digest)

--- a/fairgraph/openminds/core/data/license.py
+++ b/fairgraph/openminds/core/data/license.py
@@ -48,6 +48,8 @@ class License(KGObject):
             multiple=True,
             doc="Hypertext document (block of information) found on the World Wide Web.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_applied_to",
             [

--- a/fairgraph/openminds/core/data/measurement.py
+++ b/fairgraph/openminds/core/data/measurement.py
@@ -59,6 +59,7 @@ class Measurement(EmbeddedMetadata):
             doc="Entry for a property.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/core/data/service_link.py
+++ b/fairgraph/openminds/core/data/service_link.py
@@ -51,6 +51,7 @@ class ServiceLink(KGObject):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("data_location", "open_data_in", "service")
 
     def __init__(

--- a/fairgraph/openminds/core/digital_identifier/doi.py
+++ b/fairgraph/openminds/core/digital_identifier/doi.py
@@ -24,6 +24,8 @@ class DOI(KGObject):
     }
     properties = [
         Property("identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the DOI."),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             ["openminds.core.BehavioralProtocol", "openminds.core.Protocol"],

--- a/fairgraph/openminds/core/digital_identifier/gridid.py
+++ b/fairgraph/openminds/core/digital_identifier/gridid.py
@@ -26,6 +26,8 @@ class GRIDID(KGObject):
         Property(
             "identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the GRIDID."
         ),
+    ]
+    reverse_properties = [
         Property(
             "identifies",
             "openminds.core.Organization",

--- a/fairgraph/openminds/core/digital_identifier/handle.py
+++ b/fairgraph/openminds/core/digital_identifier/handle.py
@@ -26,6 +26,8 @@ class HANDLE(KGObject):
         Property(
             "identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the HANDLE."
         ),
+    ]
+    reverse_properties = [
         Property(
             "related_to",
             [

--- a/fairgraph/openminds/core/digital_identifier/identifiers_dot_org_id.py
+++ b/fairgraph/openminds/core/digital_identifier/identifiers_dot_org_id.py
@@ -30,6 +30,8 @@ class IdentifiersDotOrgID(KGObject):
             required=True,
             doc="Term or code used to identify the identifiers dot org i d.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "identifies",
             ["openminds.core.Dataset", "openminds.core.DatasetVersion"],

--- a/fairgraph/openminds/core/digital_identifier/isbn.py
+++ b/fairgraph/openminds/core/digital_identifier/isbn.py
@@ -24,6 +24,8 @@ class ISBN(KGObject):
     }
     properties = [
         Property("identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the ISBN."),
+    ]
+    reverse_properties = [
         Property(
             "cited_in",
             [

--- a/fairgraph/openminds/core/digital_identifier/issn.py
+++ b/fairgraph/openminds/core/digital_identifier/issn.py
@@ -24,6 +24,8 @@ class ISSN(KGObject):
     }
     properties = [
         Property("identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the ISSN."),
+    ]
+    reverse_properties = [
         Property(
             "identifies",
             "openminds.publications.Periodical",

--- a/fairgraph/openminds/core/digital_identifier/orcid.py
+++ b/fairgraph/openminds/core/digital_identifier/orcid.py
@@ -24,6 +24,8 @@ class ORCID(KGObject):
     }
     properties = [
         Property("identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the ORCID."),
+    ]
+    reverse_properties = [
         Property(
             "identifies",
             "openminds.core.Person",

--- a/fairgraph/openminds/core/digital_identifier/rorid.py
+++ b/fairgraph/openminds/core/digital_identifier/rorid.py
@@ -24,6 +24,8 @@ class RORID(KGObject):
     }
     properties = [
         Property("identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the RORID."),
+    ]
+    reverse_properties = [
         Property(
             "identifies",
             "openminds.core.Organization",

--- a/fairgraph/openminds/core/digital_identifier/rrid.py
+++ b/fairgraph/openminds/core/digital_identifier/rrid.py
@@ -24,6 +24,8 @@ class RRID(KGObject):
     }
     properties = [
         Property("identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the RRID."),
+    ]
+    reverse_properties = [
         Property(
             "identifies",
             [

--- a/fairgraph/openminds/core/digital_identifier/stock_number.py
+++ b/fairgraph/openminds/core/digital_identifier/stock_number.py
@@ -29,6 +29,7 @@ class StockNumber(EmbeddedMetadata):
             "vendor", "openminds.core.Organization", "vocab:vendor", required=True, doc="no description available"
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, identifier=None, vendor=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, identifier=identifier, vendor=vendor)

--- a/fairgraph/openminds/core/digital_identifier/swhid.py
+++ b/fairgraph/openminds/core/digital_identifier/swhid.py
@@ -24,6 +24,8 @@ class SWHID(KGObject):
     }
     properties = [
         Property("identifier", str, "vocab:identifier", required=True, doc="Term or code used to identify the SWHID."),
+    ]
+    reverse_properties = [
         Property(
             "identifies",
             [

--- a/fairgraph/openminds/core/miscellaneous/comment.py
+++ b/fairgraph/openminds/core/miscellaneous/comment.py
@@ -60,6 +60,7 @@ class Comment(KGObject):
         ),
         Property("timestamp", datetime, "vocab:timestamp", required=True, doc="no description available"),
     ]
+    reverse_properties = []
     existence_query_properties = ("about", "comment", "commenter", "timestamp")
 
     def __init__(

--- a/fairgraph/openminds/core/miscellaneous/funding.py
+++ b/fairgraph/openminds/core/miscellaneous/funding.py
@@ -48,6 +48,8 @@ class Funding(KGObject):
             required=True,
             doc="Legal person that provides money for a particular purpose.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "funded",
             [

--- a/fairgraph/openminds/core/miscellaneous/quantitative_value.py
+++ b/fairgraph/openminds/core/miscellaneous/quantitative_value.py
@@ -43,7 +43,7 @@ class QuantitativeValue(EmbeddedMetadata):
         ),
         Property("value", float, "vocab:value", required=True, doc="Entry for a property."),
     ]
-    existence_query_properties = ("value", "unit", "uncertainties")
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/core/miscellaneous/quantitative_value_array.py
+++ b/fairgraph/openminds/core/miscellaneous/quantitative_value_array.py
@@ -51,6 +51,7 @@ class QuantitativeValueArray(KGObject):
         ),
         Property("values", float, "vocab:values", multiple=True, required=True, doc="no description available"),
     ]
+    reverse_properties = []
     existence_query_properties = ("values",)
 
     def __init__(

--- a/fairgraph/openminds/core/miscellaneous/quantitative_value_range.py
+++ b/fairgraph/openminds/core/miscellaneous/quantitative_value_range.py
@@ -37,6 +37,7 @@ class QuantitativeValueRange(EmbeddedMetadata):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/core/miscellaneous/research_product_group.py
+++ b/fairgraph/openminds/core/miscellaneous/research_product_group.py
@@ -54,6 +54,7 @@ class ResearchProductGroup(KGObject):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("context", "has_parts")
 
     def __init__(self, context=None, has_parts=None, id=None, data=None, space=None, scope=None):

--- a/fairgraph/openminds/core/miscellaneous/web_resource.py
+++ b/fairgraph/openminds/core/miscellaneous/web_resource.py
@@ -40,6 +40,8 @@ class WebResource(KGObject):
             required=True,
             doc="Stands for Internationalized Resource Identifier which is an internet protocol standard that builds on the URI protocol, extending the set of permitted characters to include Unicode/ISO 10646.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "describes",
             ["openminds.core.BehavioralProtocol", "openminds.core.Protocol"],

--- a/fairgraph/openminds/core/products/dataset.py
+++ b/fairgraph/openminds/core/products/dataset.py
@@ -77,6 +77,8 @@ class Dataset(KGObject):
             required=True,
             doc="Shortened or fully abbreviated name of the dataset.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/dataset_version.py
+++ b/fairgraph/openminds/core/products/dataset_version.py
@@ -101,7 +101,7 @@ class DatasetVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -193,6 +193,7 @@ class DatasetVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -358,6 +359,7 @@ class DatasetVersion(KGObject):
             "techniques",
             [
                 "openminds.controlled_terms.AnalysisTechnique",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.StimulationApproach",
                 "openminds.controlled_terms.StimulationTechnique",
                 "openminds.controlled_terms.Technique",
@@ -381,6 +383,8 @@ class DatasetVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/meta_data_model.py
+++ b/fairgraph/openminds/core/products/meta_data_model.py
@@ -83,6 +83,8 @@ class MetaDataModel(KGObject):
             required=True,
             doc="Shortened or fully abbreviated name of the meta data model.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/meta_data_model_version.py
+++ b/fairgraph/openminds/core/products/meta_data_model_version.py
@@ -68,7 +68,7 @@ class MetaDataModelVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -146,6 +146,7 @@ class MetaDataModelVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -280,6 +281,8 @@ class MetaDataModelVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/model.py
+++ b/fairgraph/openminds/core/products/model.py
@@ -128,6 +128,8 @@ class Model(KGObject):
             required=True,
             doc="Structure or function that was targeted within a study.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/model_version.py
+++ b/fairgraph/openminds/core/products/model_version.py
@@ -77,7 +77,7 @@ class ModelVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -160,6 +160,7 @@ class ModelVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -281,6 +282,8 @@ class ModelVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/project.py
+++ b/fairgraph/openminds/core/products/project.py
@@ -79,6 +79,7 @@ class Project(KGObject):
             doc="Shortened or fully abbreviated name of the project.",
         ),
     ]
+    reverse_properties = []
     aliases = {"name": "full_name", "alias": "short_name"}
     existence_query_properties = ("short_name",)
 

--- a/fairgraph/openminds/core/products/setup.py
+++ b/fairgraph/openminds/core/products/setup.py
@@ -67,6 +67,8 @@ class Setup(KGObject):
             multiple=True,
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_part_of",
             "openminds.core.Setup",

--- a/fairgraph/openminds/core/products/software.py
+++ b/fairgraph/openminds/core/products/software.py
@@ -79,6 +79,8 @@ class Software(KGObject):
             required=True,
             doc="Shortened or fully abbreviated name of the software.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/software_version.py
+++ b/fairgraph/openminds/core/products/software_version.py
@@ -93,7 +93,7 @@ class SoftwareVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -183,6 +183,7 @@ class SoftwareVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -335,6 +336,8 @@ class SoftwareVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/web_service.py
+++ b/fairgraph/openminds/core/products/web_service.py
@@ -73,6 +73,8 @@ class WebService(KGObject):
             required=True,
             doc="Shortened or fully abbreviated name of the web service.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/products/web_service_version.py
+++ b/fairgraph/openminds/core/products/web_service_version.py
@@ -63,7 +63,7 @@ class WebServiceVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -153,6 +153,7 @@ class WebServiceVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -266,6 +267,8 @@ class WebServiceVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/core/research/behavioral_protocol.py
+++ b/fairgraph/openminds/core/research/behavioral_protocol.py
@@ -72,6 +72,8 @@ class BehavioralProtocol(KGObject):
             multiple=True,
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_used_to_group",
             "openminds.core.FileBundle",

--- a/fairgraph/openminds/core/research/configuration.py
+++ b/fairgraph/openminds/core/research/configuration.py
@@ -32,6 +32,8 @@ class Configuration(KGObject):
             doc="Method of digitally organizing and structuring data or information.",
         ),
         Property("lookup_label", str, "vocab:lookupLabel", doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "is_configuration_of",
             [

--- a/fairgraph/openminds/core/research/custom_property_set.py
+++ b/fairgraph/openminds/core/research/custom_property_set.py
@@ -34,6 +34,7 @@ class CustomPropertySet(EmbeddedMetadata):
             "relevant_for",
             [
                 "openminds.controlled_terms.AnalysisTechnique",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.StimulationApproach",
                 "openminds.controlled_terms.StimulationTechnique",
                 "openminds.controlled_terms.Technique",
@@ -43,6 +44,7 @@ class CustomPropertySet(EmbeddedMetadata):
             doc="Reference to what or whom the custom property set bears significance.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self, context=None, data_location=None, relevant_for=None, id=None, data=None, space=None, scope=None

--- a/fairgraph/openminds/core/research/numerical_property.py
+++ b/fairgraph/openminds/core/research/numerical_property.py
@@ -38,6 +38,7 @@ class NumericalProperty(EmbeddedMetadata):
             doc="Entry for a property.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, name=None, values=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, name=name, values=values)

--- a/fairgraph/openminds/core/research/property_value_list.py
+++ b/fairgraph/openminds/core/research/property_value_list.py
@@ -32,6 +32,8 @@ class PropertyValueList(KGObject):
             required=True,
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "defines_environment_of",
             "openminds.computation.LaunchConfiguration",

--- a/fairgraph/openminds/core/research/protocol.py
+++ b/fairgraph/openminds/core/research/protocol.py
@@ -62,6 +62,7 @@ class Protocol(KGObject):
             "techniques",
             [
                 "openminds.controlled_terms.AnalysisTechnique",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.StimulationApproach",
                 "openminds.controlled_terms.StimulationTechnique",
                 "openminds.controlled_terms.Technique",
@@ -71,6 +72,8 @@ class Protocol(KGObject):
             required=True,
             doc="Method of accomplishing a desired aim.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "used_in",
             [

--- a/fairgraph/openminds/core/research/protocol_execution.py
+++ b/fairgraph/openminds/core/research/protocol_execution.py
@@ -145,6 +145,8 @@ class ProtocolExecution(KGObject):
             multiple=True,
             doc="Structure or function that was targeted within a study.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "based_on_protocol_execution",
             ["openminds.sands.AtlasAnnotation", "openminds.sands.CustomAnnotation"],

--- a/fairgraph/openminds/core/research/strain.py
+++ b/fairgraph/openminds/core/research/strain.py
@@ -96,6 +96,8 @@ class Strain(KGObject):
             multiple=True,
             doc="Words or expressions used in the same language that have the same or nearly the same meaning in some or all senses.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_background_strain_of",
             "openminds.core.Strain",

--- a/fairgraph/openminds/core/research/string_property.py
+++ b/fairgraph/openminds/core/research/string_property.py
@@ -31,6 +31,7 @@ class StringProperty(EmbeddedMetadata):
         ),
         Property("value", str, "vocab:value", required=True, doc="Entry for a property."),
     ]
+    reverse_properties = []
 
     def __init__(self, name=None, value=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, name=name, value=value)

--- a/fairgraph/openminds/core/research/subject.py
+++ b/fairgraph/openminds/core/research/subject.py
@@ -58,6 +58,8 @@ class Subject(KGObject):
             required=True,
             doc="Reference to a point in time at which the subject was studied in a particular mode or condition.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_study_results_in",
             "openminds.core.DatasetVersion",

--- a/fairgraph/openminds/core/research/subject_group.py
+++ b/fairgraph/openminds/core/research/subject_group.py
@@ -60,6 +60,8 @@ class SubjectGroup(KGObject):
             required=True,
             doc="Reference to a point in time at which the subject group was studied in a particular mode or condition.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_parts",
             "openminds.core.Subject",

--- a/fairgraph/openminds/core/research/subject_group_state.py
+++ b/fairgraph/openminds/core/research/subject_group_state.py
@@ -86,6 +86,8 @@ class SubjectGroupState(KGObject):
             "vocab:weight",
             doc="Amount that a thing or being weighs.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_children",
             [

--- a/fairgraph/openminds/core/research/subject_state.py
+++ b/fairgraph/openminds/core/research/subject_state.py
@@ -84,6 +84,8 @@ class SubjectState(KGObject):
             "vocab:weight",
             doc="Amount that a thing or being weighs.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_children",
             [

--- a/fairgraph/openminds/core/research/tissue_sample.py
+++ b/fairgraph/openminds/core/research/tissue_sample.py
@@ -99,6 +99,8 @@ class TissueSample(KGObject):
             required=True,
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_study_results_in",
             "openminds.core.DatasetVersion",

--- a/fairgraph/openminds/core/research/tissue_sample_collection.py
+++ b/fairgraph/openminds/core/research/tissue_sample_collection.py
@@ -103,6 +103,8 @@ class TissueSampleCollection(KGObject):
             required=True,
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_parts",
             "openminds.core.TissueSample",

--- a/fairgraph/openminds/core/research/tissue_sample_collection_state.py
+++ b/fairgraph/openminds/core/research/tissue_sample_collection_state.py
@@ -80,6 +80,8 @@ class TissueSampleCollectionState(KGObject):
             "vocab:weight",
             doc="Amount that a thing or being weighs.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_children",
             ["openminds.core.TissueSampleCollectionState", "openminds.core.TissueSampleState"],

--- a/fairgraph/openminds/core/research/tissue_sample_state.py
+++ b/fairgraph/openminds/core/research/tissue_sample_state.py
@@ -80,6 +80,8 @@ class TissueSampleState(KGObject):
             "vocab:weight",
             doc="Amount that a thing or being weighs.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_children",
             ["openminds.core.TissueSampleCollectionState", "openminds.core.TissueSampleState"],

--- a/fairgraph/openminds/ephys/activity/cell_patching.py
+++ b/fairgraph/openminds/ephys/activity/cell_patching.py
@@ -160,6 +160,7 @@ class CellPatching(KGObject):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("lookup_label",)
 
     def __init__(

--- a/fairgraph/openminds/ephys/activity/electrode_placement.py
+++ b/fairgraph/openminds/ephys/activity/electrode_placement.py
@@ -142,6 +142,7 @@ class ElectrodePlacement(KGObject):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("lookup_label",)
 
     def __init__(

--- a/fairgraph/openminds/ephys/activity/recording_activity.py
+++ b/fairgraph/openminds/ephys/activity/recording_activity.py
@@ -141,6 +141,7 @@ class RecordingActivity(KGObject):
             doc="Structure or function that was targeted within a study.",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("lookup_label",)
 
     def __init__(

--- a/fairgraph/openminds/ephys/device/electrode.py
+++ b/fairgraph/openminds/ephys/device/electrode.py
@@ -97,6 +97,8 @@ class Electrode(KGObject):
             doc="no description available",
         ),
         Property("serial_number", str, "vocab:serialNumber", doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "is_part_of",
             "openminds.core.Setup",

--- a/fairgraph/openminds/ephys/device/electrode_array.py
+++ b/fairgraph/openminds/ephys/device/electrode_array.py
@@ -108,6 +108,8 @@ class ElectrodeArray(KGObject):
             doc="no description available",
         ),
         Property("serial_number", str, "vocab:serialNumber", doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "is_part_of",
             "openminds.core.Setup",

--- a/fairgraph/openminds/ephys/device/electrode_array_usage.py
+++ b/fairgraph/openminds/ephys/device/electrode_array_usage.py
@@ -91,6 +91,8 @@ class ElectrodeArrayUsage(KGObject):
             "vocab:usedSpecimen",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "generation_device",
             "openminds.stimulation.EphysStimulus",

--- a/fairgraph/openminds/ephys/device/electrode_usage.py
+++ b/fairgraph/openminds/ephys/device/electrode_usage.py
@@ -71,6 +71,8 @@ class ElectrodeUsage(KGObject):
             "vocab:usedSpecimen",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "generation_device",
             "openminds.stimulation.EphysStimulus",

--- a/fairgraph/openminds/ephys/device/pipette.py
+++ b/fairgraph/openminds/ephys/device/pipette.py
@@ -93,6 +93,8 @@ class Pipette(KGObject):
             doc="no description available",
         ),
         Property("serial_number", str, "vocab:serialNumber", doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "is_part_of",
             "openminds.core.Setup",

--- a/fairgraph/openminds/ephys/device/pipette_usage.py
+++ b/fairgraph/openminds/ephys/device/pipette_usage.py
@@ -131,6 +131,8 @@ class PipetteUsage(KGObject):
             "vocab:usedSpecimen",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "generation_device",
             "openminds.stimulation.EphysStimulus",

--- a/fairgraph/openminds/ephys/entity/channel.py
+++ b/fairgraph/openminds/ephys/entity/channel.py
@@ -37,6 +37,7 @@ class Channel(EmbeddedMetadata):
             doc="Determinate quantity adopted as a standard of measurement.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, internal_identifier=None, unit=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, internal_identifier=internal_identifier, unit=unit)

--- a/fairgraph/openminds/ephys/entity/recording.py
+++ b/fairgraph/openminds/ephys/entity/recording.py
@@ -81,6 +81,8 @@ class Recording(KGObject):
             required=True,
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "next_recording",
             "openminds.ephys.Recording",

--- a/fairgraph/openminds/publications/book.py
+++ b/fairgraph/openminds/publications/book.py
@@ -119,6 +119,7 @@ class Book(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -189,6 +190,8 @@ class Book(KGObject):
             "vocab:versionIdentifier",
             doc="Term or code used to identify the version of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_parts",
             "openminds.publications.Chapter",

--- a/fairgraph/openminds/publications/chapter.py
+++ b/fairgraph/openminds/publications/chapter.py
@@ -127,6 +127,7 @@ class Chapter(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -198,6 +199,8 @@ class Chapter(KGObject):
             "vocab:versionIdentifier",
             doc="Term or code used to identify the version of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "related_to",
             [

--- a/fairgraph/openminds/publications/learning_resource.py
+++ b/fairgraph/openminds/publications/learning_resource.py
@@ -154,6 +154,7 @@ class LearningResource(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -241,6 +242,7 @@ class LearningResource(KGObject):
             doc="Term or code used to identify the version of something.",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("about", "name", "publication_date")
 
     def __init__(

--- a/fairgraph/openminds/publications/live_paper.py
+++ b/fairgraph/openminds/publications/live_paper.py
@@ -79,6 +79,8 @@ class LivePaper(KGObject):
             required=True,
             doc="Shortened or fully abbreviated name of the live paper.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/publications/live_paper_resource_item.py
+++ b/fairgraph/openminds/publications/live_paper_resource_item.py
@@ -54,6 +54,8 @@ class LivePaperResourceItem(KGObject):
             required=True,
             doc="Word or phrase that constitutes the distinctive designation of the live paper resource item.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_location_of",
             "openminds.core.ServiceLink",

--- a/fairgraph/openminds/publications/live_paper_section.py
+++ b/fairgraph/openminds/publications/live_paper_section.py
@@ -51,6 +51,8 @@ class LivePaperSection(KGObject):
             required=True,
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_parts",
             "openminds.publications.LivePaperResourceItem",

--- a/fairgraph/openminds/publications/live_paper_version.py
+++ b/fairgraph/openminds/publications/live_paper_version.py
@@ -78,7 +78,7 @@ class LivePaperVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -154,6 +154,7 @@ class LivePaperVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -268,6 +269,8 @@ class LivePaperVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/publications/periodical.py
+++ b/fairgraph/openminds/publications/periodical.py
@@ -36,6 +36,8 @@ class Periodical(KGObject):
             "vocab:name",
             doc="Word or phrase that constitutes the distinctive designation of the periodical.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_parts",
             "openminds.publications.PublicationVolume",

--- a/fairgraph/openminds/publications/publication_issue.py
+++ b/fairgraph/openminds/publications/publication_issue.py
@@ -31,6 +31,8 @@ class PublicationIssue(KGObject):
             doc="Reference to the ensemble of multiple things or beings.",
         ),
         Property("issue_number", str, "vocab:issueNumber", required=True, doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "has_parts",
             "openminds.publications.ScholarlyArticle",

--- a/fairgraph/openminds/publications/publication_volume.py
+++ b/fairgraph/openminds/publications/publication_volume.py
@@ -31,6 +31,8 @@ class PublicationVolume(KGObject):
             doc="Reference to the ensemble of multiple things or beings.",
         ),
         Property("volume_number", str, "vocab:volumeNumber", required=True, doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "has_parts",
             ["openminds.publications.PublicationIssue", "openminds.publications.ScholarlyArticle"],

--- a/fairgraph/openminds/publications/scholarly_article.py
+++ b/fairgraph/openminds/publications/scholarly_article.py
@@ -129,6 +129,7 @@ class ScholarlyArticle(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -200,6 +201,8 @@ class ScholarlyArticle(KGObject):
             "vocab:versionIdentifier",
             doc="Term or code used to identify the version of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "related_to",
             [

--- a/fairgraph/openminds/sands/atlas/atlas_annotation.py
+++ b/fairgraph/openminds/sands/atlas/atlas_annotation.py
@@ -89,6 +89,7 @@ class AtlasAnnotation(EmbeddedMetadata):
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/sands/atlas/brain_atlas.py
+++ b/fairgraph/openminds/sands/atlas/brain_atlas.py
@@ -96,6 +96,8 @@ class BrainAtlas(KGObject):
         Property(
             "used_species", "openminds.controlled_terms.Species", "vocab:usedSpecies", doc="no description available"
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/sands/atlas/brain_atlas_version.py
+++ b/fairgraph/openminds/sands/atlas/brain_atlas_version.py
@@ -76,7 +76,7 @@ class BrainAtlasVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -159,6 +159,7 @@ class BrainAtlasVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -297,6 +298,8 @@ class BrainAtlasVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/sands/atlas/common_coordinate_space.py
+++ b/fairgraph/openminds/sands/atlas/common_coordinate_space.py
@@ -97,6 +97,8 @@ class CommonCoordinateSpace(KGObject):
             required=True,
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/sands/atlas/common_coordinate_space_version.py
+++ b/fairgraph/openminds/sands/atlas/common_coordinate_space_version.py
@@ -91,7 +91,7 @@ class CommonCoordinateSpaceVersion(KGObject):
         ),
         Property(
             "full_documentation",
-            ["openminds.core.DOI", "openminds.core.File", "openminds.core.WebResource"],
+            ["openminds.core.DOI", "openminds.core.File", "openminds.core.ISBN", "openminds.core.WebResource"],
             "vocab:fullDocumentation",
             required=True,
             doc="Non-abridged instructions, comments, and information for using a particular product.",
@@ -172,6 +172,7 @@ class CommonCoordinateSpaceVersion(KGObject):
                 "openminds.controlled_terms.Language",
                 "openminds.controlled_terms.Laterality",
                 "openminds.controlled_terms.LearningResourceType",
+                "openminds.controlled_terms.MRIPulseSequence",
                 "openminds.controlled_terms.MeasuredQuantity",
                 "openminds.controlled_terms.MeasuredSignalType",
                 "openminds.controlled_terms.MetaDataModelType",
@@ -310,6 +311,8 @@ class CommonCoordinateSpaceVersion(KGObject):
             required=True,
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "comments",
             "openminds.core.Comment",

--- a/fairgraph/openminds/sands/atlas/parcellation_entity.py
+++ b/fairgraph/openminds/sands/atlas/parcellation_entity.py
@@ -66,6 +66,8 @@ class ParcellationEntity(KGObject):
             "vocab:relatedUBERONTerm",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_children",
             ["openminds.sands.ParcellationEntity", "openminds.sands.ParcellationEntityVersion"],

--- a/fairgraph/openminds/sands/atlas/parcellation_entity_version.py
+++ b/fairgraph/openminds/sands/atlas/parcellation_entity_version.py
@@ -81,6 +81,8 @@ class ParcellationEntityVersion(KGObject):
             "vocab:versionInnovation",
             doc="Documentation on what changed in comparison to a previously published form of something.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "has_children",
             "openminds.sands.ParcellationEntityVersion",

--- a/fairgraph/openminds/sands/atlas/parcellation_terminology.py
+++ b/fairgraph/openminds/sands/atlas/parcellation_terminology.py
@@ -45,6 +45,7 @@ class ParcellationTerminology(EmbeddedMetadata):
             doc="Term or code used to identify the parcellation terminology registered within a particular ontology.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/sands/atlas/parcellation_terminology_version.py
+++ b/fairgraph/openminds/sands/atlas/parcellation_terminology_version.py
@@ -45,6 +45,7 @@ class ParcellationTerminologyVersion(EmbeddedMetadata):
             doc="Term or code used to identify the parcellation terminology version registered within a particular ontology.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/sands/mathematical_shapes/circle.py
+++ b/fairgraph/openminds/sands/mathematical_shapes/circle.py
@@ -26,6 +26,7 @@ class Circle(EmbeddedMetadata):
             "radius", "openminds.core.QuantitativeValue", "vocab:radius", required=True, doc="no description available"
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, radius=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, radius=radius)

--- a/fairgraph/openminds/sands/mathematical_shapes/ellipse.py
+++ b/fairgraph/openminds/sands/mathematical_shapes/ellipse.py
@@ -37,6 +37,7 @@ class Ellipse(EmbeddedMetadata):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, semi_major_axis=None, semi_minor_axis=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, semi_major_axis=semi_major_axis, semi_minor_axis=semi_minor_axis)

--- a/fairgraph/openminds/sands/mathematical_shapes/rectangle.py
+++ b/fairgraph/openminds/sands/mathematical_shapes/rectangle.py
@@ -29,6 +29,7 @@ class Rectangle(EmbeddedMetadata):
             "width", "openminds.core.QuantitativeValue", "vocab:width", required=True, doc="no description available"
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, length=None, width=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, length=length, width=width)

--- a/fairgraph/openminds/sands/miscellaneous/anatomical_target_position.py
+++ b/fairgraph/openminds/sands/miscellaneous/anatomical_target_position.py
@@ -60,6 +60,7 @@ class AnatomicalTargetPosition(EmbeddedMetadata):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/sands/miscellaneous/coordinate_point.py
+++ b/fairgraph/openminds/sands/miscellaneous/coordinate_point.py
@@ -38,6 +38,7 @@ class CoordinatePoint(EmbeddedMetadata):
             doc="Pair or triplet of numbers defining a location in a given coordinate space.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(self, coordinate_space=None, coordinates=None, id=None, data=None, space=None, scope=None):
         return super().__init__(data=data, coordinate_space=coordinate_space, coordinates=coordinates)

--- a/fairgraph/openminds/sands/miscellaneous/qualitative_relation_assessment.py
+++ b/fairgraph/openminds/sands/miscellaneous/qualitative_relation_assessment.py
@@ -47,6 +47,7 @@ class QualitativeRelationAssessment(EmbeddedMetadata):
             doc="Semantic characterization of how much two things occupy the same space.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self, criteria=None, in_relation_to=None, qualitative_overlap=None, id=None, data=None, space=None, scope=None

--- a/fairgraph/openminds/sands/miscellaneous/quantitative_relation_assessment.py
+++ b/fairgraph/openminds/sands/miscellaneous/quantitative_relation_assessment.py
@@ -43,6 +43,7 @@ class QuantitativeRelationAssessment(EmbeddedMetadata):
             doc="Numerical characterization of how much two things occupy the same space.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self, criteria=None, in_relation_to=None, quantitative_overlap=None, id=None, data=None, space=None, scope=None

--- a/fairgraph/openminds/sands/miscellaneous/single_color.py
+++ b/fairgraph/openminds/sands/miscellaneous/single_color.py
@@ -25,6 +25,7 @@ class SingleColor(KGObject):
     properties = [
         Property("value", str, "vocab:value", required=True, doc="Entry for a property."),
     ]
+    reverse_properties = []
     existence_query_properties = ("value",)
 
     def __init__(self, value=None, id=None, data=None, space=None, scope=None):

--- a/fairgraph/openminds/sands/miscellaneous/viewer_specification.py
+++ b/fairgraph/openminds/sands/miscellaneous/viewer_specification.py
@@ -49,6 +49,7 @@ class ViewerSpecification(EmbeddedMetadata):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/sands/non_atlas/custom_anatomical_entity.py
+++ b/fairgraph/openminds/sands/non_atlas/custom_anatomical_entity.py
@@ -50,6 +50,8 @@ class CustomAnatomicalEntity(KGObject):
             multiple=True,
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_location_of",
             [

--- a/fairgraph/openminds/sands/non_atlas/custom_annotation.py
+++ b/fairgraph/openminds/sands/non_atlas/custom_annotation.py
@@ -96,6 +96,7 @@ class CustomAnnotation(EmbeddedMetadata):
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
     ]
+    reverse_properties = []
 
     def __init__(
         self,

--- a/fairgraph/openminds/sands/non_atlas/custom_coordinate_space.py
+++ b/fairgraph/openminds/sands/non_atlas/custom_coordinate_space.py
@@ -59,6 +59,8 @@ class CustomCoordinateSpace(KGObject):
             required=True,
             doc="Determinate quantity used in the original measurement.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_coordinate_space_of",
             "openminds.sands.CustomAnnotation",

--- a/fairgraph/openminds/specimen_prep/activity/cranial_window_preparation.py
+++ b/fairgraph/openminds/specimen_prep/activity/cranial_window_preparation.py
@@ -142,6 +142,7 @@ class CranialWindowPreparation(KGObject):
             doc="Structure or function that was targeted within a study.",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("lookup_label",)
 
     def __init__(

--- a/fairgraph/openminds/specimen_prep/activity/tissue_culture_preparation.py
+++ b/fairgraph/openminds/specimen_prep/activity/tissue_culture_preparation.py
@@ -142,6 +142,7 @@ class TissueCulturePreparation(KGObject):
             doc="Structure or function that was targeted within a study.",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("lookup_label",)
 
     def __init__(

--- a/fairgraph/openminds/specimen_prep/activity/tissue_sample_slicing.py
+++ b/fairgraph/openminds/specimen_prep/activity/tissue_sample_slicing.py
@@ -146,6 +146,7 @@ class TissueSampleSlicing(KGObject):
             doc="no description available",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("lookup_label",)
 
     def __init__(

--- a/fairgraph/openminds/specimen_prep/device/slicing_device.py
+++ b/fairgraph/openminds/specimen_prep/device/slicing_device.py
@@ -65,6 +65,8 @@ class SlicingDevice(KGObject):
             doc="no description available",
         ),
         Property("serial_number", str, "vocab:serialNumber", doc="no description available"),
+    ]
+    reverse_properties = [
         Property(
             "is_part_of",
             "openminds.core.Setup",

--- a/fairgraph/openminds/specimen_prep/device/slicing_device_usage.py
+++ b/fairgraph/openminds/specimen_prep/device/slicing_device_usage.py
@@ -80,6 +80,8 @@ class SlicingDeviceUsage(KGObject):
             "vocab:vibrationFrequency",
             doc="no description available",
         ),
+    ]
+    reverse_properties = [
         Property(
             "generation_device",
             "openminds.stimulation.EphysStimulus",

--- a/fairgraph/openminds/stimulation/activity/stimulation_activity.py
+++ b/fairgraph/openminds/stimulation/activity/stimulation_activity.py
@@ -142,6 +142,7 @@ class StimulationActivity(KGObject):
             doc="Structure or function that was targeted within a study.",
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("lookup_label",)
 
     def __init__(

--- a/fairgraph/openminds/stimulation/stimulus/ephys_stimulus.py
+++ b/fairgraph/openminds/stimulation/stimulus/ephys_stimulus.py
@@ -78,6 +78,8 @@ class EphysStimulus(KGObject):
             "vocab:type",
             doc="Distinct class to which a group of entities or concepts with similar characteristics or attributes belong to.",
         ),
+    ]
+    reverse_properties = [
         Property(
             "is_stimulus_for",
             "openminds.stimulation.StimulationActivity",

--- a/fairgraph/properties.py
+++ b/fairgraph/properties.py
@@ -343,7 +343,7 @@ class Property(object):
             for cls in possible_classes:
                 for path in self.path:
                     assert path.startswith("^")
-                    for prop in cls.properties:
+                    for prop in cls.all_properties:
                         if path[1:] == prop.path:
                             property_name = path
                             found_match = True

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -43,6 +43,7 @@ class MockEmbeddedObject(EmbeddedMetadata):
             required=True,
         ),
     ]
+    reverse_properties = []
     existence_query_properties = ("a_number",)
 
 
@@ -56,6 +57,7 @@ class MockKGObject2(KGObject):
         "mock": "https://openminds.ebrains.eu/mock/",
     }
     properties = [Property("a", int, "https://openminds.ebrains.eu/vocab/A", multiple=False, required=True)]
+    reverse_properties = []
 
 
 class MockKGObject(KGObject):
@@ -181,6 +183,7 @@ class MockKGObject(KGObject):
             required=False,
         ),
     ]
+    reverse_properties = []
     existence_query_properties = (
         "a_required_string",
         "a_required_datetime",

--- a/test/test_openminds_core.py
+++ b/test/test_openminds_core.py
@@ -19,7 +19,7 @@ import fairgraph.openminds.core as omcore
 import fairgraph.openminds.controlled_terms as omterms
 from fairgraph.utility import ActivityLog, sha1sum
 
-from test.utils import mock_client, kg_client, skip_if_no_connection
+from test.utils import mock_client, kg_client, skip_if_no_connection, skip_if_using_production_server
 
 
 def test_query_generation(mock_client):
@@ -516,6 +516,7 @@ def test_to_jsonld():
     assert person2.to_jsonld(follow_links=False) == expected2b
 
 
+@skip_if_using_production_server
 def test_save_new_mock(mock_client):
     timestamp = datetime.now()
     new_model = omcore.Model(
@@ -544,6 +545,7 @@ def test_save_new_mock(mock_client):
     assert log.entries[0].type == "create"
 
 
+@skip_if_using_production_server
 def test_save_existing_mock(mock_client):
     timestamp = datetime.now()
     new_model = omcore.Model(
@@ -574,6 +576,7 @@ def test_save_existing_mock(mock_client):
     assert log.entries[0].type == "update"
 
 
+@skip_if_using_production_server
 def test_save_existing_mock_no_updates_allowed(mock_client):
     timestamp = datetime.now()
     new_model = omcore.Model(
@@ -605,6 +608,7 @@ def test_save_existing_mock_no_updates_allowed(mock_client):
     assert log.entries[0].type == "no-op"
 
 
+@skip_if_using_production_server
 def test_save_replace_existing_mock(mock_client):
     timestamp = datetime.now()
     new_model = omcore.Model(
@@ -635,6 +639,7 @@ def test_save_replace_existing_mock(mock_client):
     assert log.entries[0].type == "replacement"
 
 
+@skip_if_using_production_server
 def test_save_new_recursive_mock(mock_client):
     new_person = omcore.Person(
         given_name="Thorin",

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -18,6 +18,7 @@ class SomeOrganization(KGObject):
         Property("name", str, "vocab:fullName", multiple=False, required=True),
         Property("alias", str, "vocab:shortName", multiple=False, required=False),
     ]
+    reverse_properties = []
     existence_query_properties = ("name",)
 
 
@@ -31,6 +32,7 @@ class SomeAffiliation(EmbeddedMetadata):
         Property("member_of", (SomeOrganization,), "vocab:memberOf", multiple=False, required=False),
         Property("start_date", date, "vocab:startDate", multiple=False, required=False),
     ]
+    reverse_properties = []
 
 
 class SomeContactInformation(KGObject):
@@ -40,6 +42,7 @@ class SomeContactInformation(KGObject):
         "vocab": "https://openminds.ebrains.eu/vocab/",
     }
     properties = [Property("email", str, "vocab:email", multiple=False, required=True)]
+    reverse_properties = []
     existence_query_properties = ("email",)
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -7,6 +7,7 @@ import pytest
 
 kg_host = "core.kg-ppd.ebrains.eu"  # don't use production for testing
 have_kg_connection = False
+
 try:
     client = KGClient(host=kg_host)
 except AuthenticationError:

--- a/test/utils.py
+++ b/test/utils.py
@@ -5,10 +5,10 @@ from fairgraph.errors import AuthenticationError
 
 import pytest
 
-
+kg_host = "core.kg-ppd.ebrains.eu"  # don't use production for testing
 have_kg_connection = False
 try:
-    client = KGClient(host="core.kg-ppd.ebrains.eu")  # don't use production for testing
+    client = KGClient(host=kg_host)
 except AuthenticationError:
     pass
 else:
@@ -20,6 +20,10 @@ no_kg_err_msg = "No KG connection - have you set the environment variable KG_AUT
 
 def skip_if_no_connection(f):
     return pytest.mark.skipif(not have_kg_connection, reason=no_kg_err_msg)(f)
+
+
+def skip_if_using_production_server(f):
+    return pytest.mark.skipif("kg-ppd" not in kg_host, reason="Using production server for testing")(f)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This is preparatory to rebuilding fairgraph on top of openMINDS Python (which doesn't have reverse properties).