### PR TITLE
Fix some errors that prevented tests being skipped when the KG is unavailable

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -243,6 +243,10 @@ def offline_kg_client(mocker):
     must be patched per-test."""
     from fairgraph.client import KGClient
 
+    # Building the kg-core client fetches the IAM token endpoint from the KG, which
+    # fails if the KG is unreachable (e.g. during maintenance).
+    mocker.patch("kg_core.__communication.TokenHandler.define_endpoint")
+
     client = KGClient(token="fake-token", allow_interactive=False)
     # Skip the feature-detection fetch that the `migrated` property triggers.
     client._migrated = True

--- a/test/utils.py
+++ b/test/utils.py
@@ -3,7 +3,7 @@ import os
 from uuid import uuid4
 from typing import Optional
 
-from requests.exceptions import SSLError
+from requests.exceptions import RequestException, SSLError
 from fairgraph.client import KGClient
 from fairgraph.errors import AuthenticationError, AuthorizationError
 
@@ -20,6 +20,9 @@ except AuthenticationError:
     pass
 except SSLError:
     no_kg_err_msg = "No KG connection - SSL certificate may have expired"
+except RequestException:
+    # e.g. the KG is down for maintenance. 
+    no_kg_err_msg = f"No KG connection - could not reach {kg_host}"
 else:
     try:
         user_info = client.user_info()


### PR DESCRIPTION
Trying to run the test suite during an outage on JSC Cloud revealed these bugs!